### PR TITLE
Release 6.1.0 / Plugins 3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [6.1.0] - 2026-03-XX
+## [6.1.0] - 2026-03-09
 
 ### Added
 

--- a/build/coverage/pom.xml
+++ b/build/coverage/pom.xml
@@ -44,12 +44,12 @@
         <dependency>
             <groupId>io.hexaglue.plugins</groupId>
             <artifactId>hexaglue-plugin-jpa</artifactId>
-            <version>3.1.0-SNAPSHOT</version>
+            <version>3.1.0</version>
         </dependency>
         <dependency>
             <groupId>io.hexaglue.plugins</groupId>
             <artifactId>hexaglue-plugin-living-doc</artifactId>
-            <version>3.1.0-SNAPSHOT</version>
+            <version>3.1.0</version>
         </dependency>
     </dependencies>
 

--- a/build/coverage/pom.xml
+++ b/build/coverage/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.hexaglue</groupId>
         <artifactId>hexaglue-build</artifactId>
-        <version>6.1.0-SNAPSHOT</version>
+        <version>6.1.0</version>
     </parent>
 
     <artifactId>hexaglue-build-coverage</artifactId>

--- a/build/distribution/pom.xml
+++ b/build/distribution/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.hexaglue</groupId>
         <artifactId>hexaglue-build</artifactId>
-        <version>6.1.0-SNAPSHOT</version>
+        <version>6.1.0</version>
     </parent>
 
     <artifactId>hexaglue-build-distribution</artifactId>

--- a/build/integration-tests/pom.xml
+++ b/build/integration-tests/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.hexaglue</groupId>
         <artifactId>hexaglue-build</artifactId>
-        <version>6.1.0-SNAPSHOT</version>
+        <version>6.1.0</version>
     </parent>
 
     <artifactId>hexaglue-build-integration-tests</artifactId>

--- a/build/pom.xml
+++ b/build/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.hexaglue</groupId>
         <artifactId>hexaglue-parent</artifactId>
-        <version>6.1.0-SNAPSHOT</version>
+        <version>6.1.0</version>
     </parent>
 
     <artifactId>hexaglue-build</artifactId>

--- a/build/tools/pom.xml
+++ b/build/tools/pom.xml
@@ -7,7 +7,7 @@
     <!-- No parent to avoid circular dependency -->
     <groupId>io.hexaglue</groupId>
     <artifactId>hexaglue-build-tools</artifactId>
-    <version>6.1.0-SNAPSHOT</version>
+    <version>6.1.0</version>
     <packaging>jar</packaging>
 
     <name>HexaGlue Build Tools Configuration</name>

--- a/docs/ARCHITECTURE_AUDIT.md
+++ b/docs/ARCHITECTURE_AUDIT.md
@@ -48,7 +48,7 @@ The audit plugin checks 15 constraints in two categories:
 <plugin>
     <groupId>io.hexaglue</groupId>
     <artifactId>hexaglue-maven-plugin</artifactId>
-    <version>${hexaglue.version}</version>
+    <version>6.1.0</version>
     <extensions>true</extensions>
     <configuration>
         <basePackage>com.example</basePackage>
@@ -57,7 +57,7 @@ The audit plugin checks 15 constraints in two categories:
         <dependency>
             <groupId>io.hexaglue.plugins</groupId>
             <artifactId>hexaglue-plugin-audit</artifactId>
-            <version>3.0.0</version>
+            <version>3.1.0</version>
         </dependency>
     </dependencies>
 </plugin>
@@ -367,7 +367,7 @@ Full production configuration:
 <plugin>
     <groupId>io.hexaglue</groupId>
     <artifactId>hexaglue-maven-plugin</artifactId>
-    <version>${hexaglue.version}</version>
+    <version>6.1.0</version>
     <extensions>true</extensions>
     <configuration>
         <basePackage>com.example</basePackage>
@@ -377,17 +377,17 @@ Full production configuration:
         <dependency>
             <groupId>io.hexaglue.plugins</groupId>
             <artifactId>hexaglue-plugin-jpa</artifactId>
-            <version>3.0.0</version>
+            <version>3.1.0</version>
         </dependency>
         <dependency>
             <groupId>io.hexaglue.plugins</groupId>
             <artifactId>hexaglue-plugin-living-doc</artifactId>
-            <version>3.0.0</version>
+            <version>3.1.0</version>
         </dependency>
         <dependency>
             <groupId>io.hexaglue.plugins</groupId>
             <artifactId>hexaglue-plugin-audit</artifactId>
-            <version>3.0.0</version>
+            <version>3.1.0</version>
         </dependency>
     </dependencies>
 </plugin>

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -115,7 +115,7 @@ Add this to your `pom.xml`:
 <plugin>
     <groupId>io.hexaglue</groupId>
     <artifactId>hexaglue-maven-plugin</artifactId>
-    <version>6.0.0</version>
+    <version>6.1.0</version>
     <extensions>true</extensions>
     <configuration>
         <basePackage>com.example</basePackage>
@@ -131,7 +131,7 @@ mvn compile
 HexaGlue analyzes your domain and outputs a classification summary:
 
 ```
-[INFO] --- hexaglue:6.0.0:generate (default-cli) @ my-project ---
+[INFO] --- hexaglue:6.1.0:generate (default-cli) @ my-project ---
 [INFO]
 [INFO] CLASSIFICATION SUMMARY
 [INFO] --------------------------------------------------------------
@@ -159,7 +159,7 @@ To generate JPA entities and repositories, add the plugin dependency:
 <plugin>
     <groupId>io.hexaglue</groupId>
     <artifactId>hexaglue-maven-plugin</artifactId>
-    <version>6.0.0</version>
+    <version>6.1.0</version>
     <extensions>true</extensions>
     <configuration>
         <basePackage>com.example</basePackage>
@@ -168,7 +168,7 @@ To generate JPA entities and repositories, add the plugin dependency:
         <dependency>
             <groupId>io.hexaglue.plugins</groupId>
             <artifactId>hexaglue-plugin-jpa</artifactId>
-            <version>3.0.0</version>
+            <version>3.1.0</version>
         </dependency>
     </dependencies>
 </plugin>

--- a/docs/VALIDATION.md
+++ b/docs/VALIDATION.md
@@ -21,7 +21,7 @@ mvn hexaglue:validate
 ## Understanding the Output
 
 ```
-[INFO] --- hexaglue:6.0.0:validate ---
+[INFO] --- hexaglue:6.1.0:validate ---
 [INFO]
 [INFO] CLASSIFICATION SUMMARY
 [INFO] --------------------------------------------------------------

--- a/examples/sample-audit-violations/pom.xml
+++ b/examples/sample-audit-violations/pom.xml
@@ -64,7 +64,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.0-SNAPSHOT</version>
+                <version>6.1.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.example.ecommerce</basePackage>
@@ -76,13 +76,13 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-living-doc</artifactId>
-                        <version>3.1.0-SNAPSHOT</version>
+                        <version>3.1.0</version>
                     </dependency>
                     <!-- DDD Audit Plugin -->
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-audit</artifactId>
-                        <version>3.1.0-SNAPSHOT</version>
+                        <version>3.1.0</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/sample-basic/pom.xml
+++ b/examples/sample-basic/pom.xml
@@ -61,7 +61,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.0-SNAPSHOT</version>
+                <version>6.1.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.example</basePackage>
@@ -71,13 +71,13 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-living-doc</artifactId>
-                        <version>3.1.0-SNAPSHOT</version>
+                        <version>3.1.0</version>
                     </dependency>
                     <!-- DDD Audit Plugin -->
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-audit</artifactId>
-                        <version>3.1.0-SNAPSHOT</version>
+                        <version>3.1.0</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/sample-jpa-bugfixes/pom.xml
+++ b/examples/sample-jpa-bugfixes/pom.xml
@@ -66,7 +66,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.0-SNAPSHOT</version>
+                <version>6.1.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.university</basePackage>
@@ -76,19 +76,19 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-living-doc</artifactId>
-                        <version>3.1.0-SNAPSHOT</version>
+                        <version>3.1.0</version>
                     </dependency>
                     <!-- JPA Plugin -->
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-jpa</artifactId>
-                        <version>3.1.0-SNAPSHOT</version>
+                        <version>3.1.0</version>
                     </dependency>
                     <!-- DDD Audit Plugin -->
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-audit</artifactId>
-                        <version>3.1.0-SNAPSHOT</version>
+                        <version>3.1.0</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/sample-multi-aggregate/pom.xml
+++ b/examples/sample-multi-aggregate/pom.xml
@@ -73,7 +73,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.0-SNAPSHOT</version>
+                <version>6.1.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.ecommerce</basePackage>
@@ -83,25 +83,25 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-living-doc</artifactId>
-                        <version>3.1.0-SNAPSHOT</version>
+                        <version>3.1.0</version>
                     </dependency>
                     <!-- JPA Plugin -->
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-jpa</artifactId>
-                        <version>3.1.0-SNAPSHOT</version>
+                        <version>3.1.0</version>
                     </dependency>
                     <!-- DDD Audit Plugin -->
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-audit</artifactId>
-                        <version>3.1.0-SNAPSHOT</version>
+                        <version>3.1.0</version>
                     </dependency>
                     <!-- REST Plugin -->
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-rest</artifactId>
-                        <version>3.1.0-SNAPSHOT</version>
+                        <version>3.1.0</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/sample-multimodule/pom.xml
+++ b/examples/sample-multimodule/pom.xml
@@ -38,7 +38,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.0-SNAPSHOT</version>
+                <version>6.1.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.banking</basePackage>
@@ -48,19 +48,19 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-jpa</artifactId>
-                        <version>3.1.0-SNAPSHOT</version>
+                        <version>3.1.0</version>
                     </dependency>
                     <!-- Living Documentation Plugin -->
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-living-doc</artifactId>
-                        <version>3.1.0-SNAPSHOT</version>
+                        <version>3.1.0</version>
                     </dependency>
                     <!-- DDD Audit Plugin -->
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-audit</artifactId>
-                        <version>3.1.0-SNAPSHOT</version>
+                        <version>3.1.0</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/sample-pokedex/pom.xml
+++ b/examples/sample-pokedex/pom.xml
@@ -85,7 +85,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.0-SNAPSHOT</version>
+                <version>6.1.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.example</basePackage>
@@ -95,19 +95,19 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-living-doc</artifactId>
-                        <version>3.1.0-SNAPSHOT</version>
+                        <version>3.1.0</version>
                     </dependency>
                     <!-- JPA Plugin -->
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-jpa</artifactId>
-                        <version>3.1.0-SNAPSHOT</version>
+                        <version>3.1.0</version>
                     </dependency>
                     <!-- DDD Audit Plugin -->
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-audit</artifactId>
-                        <version>3.1.0-SNAPSHOT</version>
+                        <version>3.1.0</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/sample-regression-tests/pom.xml
+++ b/examples/sample-regression-tests/pom.xml
@@ -73,7 +73,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.0-SNAPSHOT</version>
+                <version>6.1.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.regression</basePackage>
@@ -83,19 +83,19 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-living-doc</artifactId>
-                        <version>3.1.0-SNAPSHOT</version>
+                        <version>3.1.0</version>
                     </dependency>
                     <!-- JPA Plugin -->
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-jpa</artifactId>
-                        <version>3.1.0-SNAPSHOT</version>
+                        <version>3.1.0</version>
                     </dependency>
                     <!-- DDD Audit Plugin -->
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-audit</artifactId>
-                        <version>3.1.0-SNAPSHOT</version>
+                        <version>3.1.0</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/sample-starwars/pom.xml
+++ b/examples/sample-starwars/pom.xml
@@ -61,7 +61,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.0-SNAPSHOT</version>
+                <version>6.1.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>rebelsrescue.fleet</basePackage>
@@ -70,17 +70,17 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-living-doc</artifactId>
-                        <version>3.1.0-SNAPSHOT</version>
+                        <version>3.1.0</version>
                     </dependency>
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-jpa</artifactId>
-                        <version>3.1.0-SNAPSHOT</version>
+                        <version>3.1.0</version>
                     </dependency>
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-audit</artifactId>
-                        <version>3.1.0-SNAPSHOT</version>
+                        <version>3.1.0</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/sample-value-objects/pom.xml
+++ b/examples/sample-value-objects/pom.xml
@@ -54,7 +54,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.0-SNAPSHOT</version>
+                <version>6.1.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.coffeeshop</basePackage>
@@ -64,19 +64,19 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-living-doc</artifactId>
-                        <version>3.1.0-SNAPSHOT</version>
+                        <version>3.1.0</version>
                     </dependency>
                     <!-- JPA Plugin -->
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-jpa</artifactId>
-                        <version>3.1.0-SNAPSHOT</version>
+                        <version>3.1.0</version>
                     </dependency>
                     <!-- DDD Audit Plugin -->
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-audit</artifactId>
-                        <version>3.1.0-SNAPSHOT</version>
+                        <version>3.1.0</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/test-param-audit-error-on-blocker/pom.xml
+++ b/examples/test-param-audit-error-on-blocker/pom.xml
@@ -24,7 +24,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.0-SNAPSHOT</version>
+                <version>6.1.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.example</basePackage>
@@ -35,7 +35,7 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-audit</artifactId>
-                        <version>3.1.0-SNAPSHOT</version>
+                        <version>3.1.0</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/test-param-audit-error-on-critical/pom.xml
+++ b/examples/test-param-audit-error-on-critical/pom.xml
@@ -24,7 +24,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.0-SNAPSHOT</version>
+                <version>6.1.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.example</basePackage>
@@ -35,7 +35,7 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-audit</artifactId>
-                        <version>3.1.0-SNAPSHOT</version>
+                        <version>3.1.0</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/test-param-audit-fail-on-error/pom.xml
+++ b/examples/test-param-audit-fail-on-error/pom.xml
@@ -24,7 +24,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.0-SNAPSHOT</version>
+                <version>6.1.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.example</basePackage>
@@ -34,7 +34,7 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-audit</artifactId>
-                        <version>3.1.0-SNAPSHOT</version>
+                        <version>3.1.0</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/test-param-audit-generate-docs/pom.xml
+++ b/examples/test-param-audit-generate-docs/pom.xml
@@ -24,7 +24,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.0-SNAPSHOT</version>
+                <version>6.1.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.example</basePackage>
@@ -33,7 +33,7 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-audit</artifactId>
-                        <version>3.1.0-SNAPSHOT</version>
+                        <version>3.1.0</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/test-param-audit-no-error-on-blocker/pom.xml
+++ b/examples/test-param-audit-no-error-on-blocker/pom.xml
@@ -24,7 +24,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.0-SNAPSHOT</version>
+                <version>6.1.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.example</basePackage>
@@ -35,7 +35,7 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-audit</artifactId>
-                        <version>3.1.0-SNAPSHOT</version>
+                        <version>3.1.0</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/test-param-audit-no-error-on-critical/pom.xml
+++ b/examples/test-param-audit-no-error-on-critical/pom.xml
@@ -24,7 +24,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.0-SNAPSHOT</version>
+                <version>6.1.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.example</basePackage>
@@ -35,7 +35,7 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-audit</artifactId>
-                        <version>3.1.0-SNAPSHOT</version>
+                        <version>3.1.0</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/test-param-audit-no-fail-on-error/pom.xml
+++ b/examples/test-param-audit-no-fail-on-error/pom.xml
@@ -24,7 +24,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.0-SNAPSHOT</version>
+                <version>6.1.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.example</basePackage>
@@ -34,7 +34,7 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-audit</artifactId>
-                        <version>3.1.0-SNAPSHOT</version>
+                        <version>3.1.0</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/test-param-audit-report-directory/pom.xml
+++ b/examples/test-param-audit-report-directory/pom.xml
@@ -24,7 +24,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.0-SNAPSHOT</version>
+                <version>6.1.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.example</basePackage>
@@ -34,7 +34,7 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-audit</artifactId>
-                        <version>3.1.0-SNAPSHOT</version>
+                        <version>3.1.0</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/test-param-classification-exclude/pom.xml
+++ b/examples/test-param-classification-exclude/pom.xml
@@ -24,7 +24,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.0-SNAPSHOT</version>
+                <version>6.1.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.example</basePackage>
@@ -33,7 +33,7 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-living-doc</artifactId>
-                        <version>3.1.0-SNAPSHOT</version>
+                        <version>3.1.0</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/test-param-classification-explicit/pom.xml
+++ b/examples/test-param-classification-explicit/pom.xml
@@ -24,7 +24,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.0-SNAPSHOT</version>
+                <version>6.1.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.example</basePackage>
@@ -33,7 +33,7 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-living-doc</artifactId>
-                        <version>3.1.0-SNAPSHOT</version>
+                        <version>3.1.0</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/test-param-classification-fail-unclassified-yaml/pom.xml
+++ b/examples/test-param-classification-fail-unclassified-yaml/pom.xml
@@ -24,7 +24,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.0-SNAPSHOT</version>
+                <version>6.1.0</version>
                 <extensions>true</extensions>
                 <executions>
                     <execution>
@@ -42,7 +42,7 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-living-doc</artifactId>
-                        <version>3.1.0-SNAPSHOT</version>
+                        <version>3.1.0</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/test-param-classification-no-inferred/pom.xml
+++ b/examples/test-param-classification-no-inferred/pom.xml
@@ -24,7 +24,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.0-SNAPSHOT</version>
+                <version>6.1.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.example</basePackage>
@@ -33,7 +33,7 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-living-doc</artifactId>
-                        <version>3.1.0-SNAPSHOT</version>
+                        <version>3.1.0</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/test-param-fail-on-unclassified/pom.xml
+++ b/examples/test-param-fail-on-unclassified/pom.xml
@@ -24,7 +24,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.0-SNAPSHOT</version>
+                <version>6.1.0</version>
                 <extensions>true</extensions>
                 <executions>
                     <execution>
@@ -39,7 +39,7 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-living-doc</artifactId>
-                        <version>3.1.0-SNAPSHOT</version>
+                        <version>3.1.0</version>
                     </dependency>
                 </dependencies>
                 <configuration>

--- a/examples/test-param-jpa-adapter-suffix/pom.xml
+++ b/examples/test-param-jpa-adapter-suffix/pom.xml
@@ -46,7 +46,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.0-SNAPSHOT</version>
+                <version>6.1.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.example</basePackage>
@@ -55,7 +55,7 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-jpa</artifactId>
-                        <version>3.1.0-SNAPSHOT</version>
+                        <version>3.1.0</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/test-param-jpa-embeddable-suffix/pom.xml
+++ b/examples/test-param-jpa-embeddable-suffix/pom.xml
@@ -46,7 +46,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.0-SNAPSHOT</version>
+                <version>6.1.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.example</basePackage>
@@ -55,7 +55,7 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-jpa</artifactId>
-                        <version>3.1.0-SNAPSHOT</version>
+                        <version>3.1.0</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/test-param-jpa-enable-auditing/pom.xml
+++ b/examples/test-param-jpa-enable-auditing/pom.xml
@@ -51,7 +51,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.0-SNAPSHOT</version>
+                <version>6.1.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.example</basePackage>
@@ -60,7 +60,7 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-jpa</artifactId>
-                        <version>3.1.0-SNAPSHOT</version>
+                        <version>3.1.0</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/test-param-jpa-enable-optimistic-locking/pom.xml
+++ b/examples/test-param-jpa-enable-optimistic-locking/pom.xml
@@ -51,7 +51,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.0-SNAPSHOT</version>
+                <version>6.1.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.example</basePackage>
@@ -60,7 +60,7 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-jpa</artifactId>
-                        <version>3.1.0-SNAPSHOT</version>
+                        <version>3.1.0</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/test-param-jpa-entity-suffix/pom.xml
+++ b/examples/test-param-jpa-entity-suffix/pom.xml
@@ -46,7 +46,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.0-SNAPSHOT</version>
+                <version>6.1.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.example</basePackage>
@@ -55,7 +55,7 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-jpa</artifactId>
-                        <version>3.1.0-SNAPSHOT</version>
+                        <version>3.1.0</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/test-param-jpa-infra-package/pom.xml
+++ b/examples/test-param-jpa-infra-package/pom.xml
@@ -51,7 +51,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.0-SNAPSHOT</version>
+                <version>6.1.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.example</basePackage>
@@ -60,7 +60,7 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-jpa</artifactId>
-                        <version>3.1.0-SNAPSHOT</version>
+                        <version>3.1.0</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/test-param-jpa-mapper-suffix/pom.xml
+++ b/examples/test-param-jpa-mapper-suffix/pom.xml
@@ -46,7 +46,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.0-SNAPSHOT</version>
+                <version>6.1.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.example</basePackage>
@@ -55,7 +55,7 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-jpa</artifactId>
-                        <version>3.1.0-SNAPSHOT</version>
+                        <version>3.1.0</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/test-param-jpa-no-adapters/pom.xml
+++ b/examples/test-param-jpa-no-adapters/pom.xml
@@ -51,7 +51,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.0-SNAPSHOT</version>
+                <version>6.1.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.example</basePackage>
@@ -60,7 +60,7 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-jpa</artifactId>
-                        <version>3.1.0-SNAPSHOT</version>
+                        <version>3.1.0</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/test-param-jpa-no-embeddables/pom.xml
+++ b/examples/test-param-jpa-no-embeddables/pom.xml
@@ -51,7 +51,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.0-SNAPSHOT</version>
+                <version>6.1.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.example</basePackage>
@@ -60,7 +60,7 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-jpa</artifactId>
-                        <version>3.1.0-SNAPSHOT</version>
+                        <version>3.1.0</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/test-param-jpa-no-mappers/pom.xml
+++ b/examples/test-param-jpa-no-mappers/pom.xml
@@ -51,7 +51,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.0-SNAPSHOT</version>
+                <version>6.1.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.example</basePackage>
@@ -60,7 +60,7 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-jpa</artifactId>
-                        <version>3.1.0-SNAPSHOT</version>
+                        <version>3.1.0</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/test-param-jpa-no-repositories/pom.xml
+++ b/examples/test-param-jpa-no-repositories/pom.xml
@@ -51,7 +51,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.0-SNAPSHOT</version>
+                <version>6.1.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.example</basePackage>
@@ -60,7 +60,7 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-jpa</artifactId>
-                        <version>3.1.0-SNAPSHOT</version>
+                        <version>3.1.0</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/test-param-jpa-repository-suffix/pom.xml
+++ b/examples/test-param-jpa-repository-suffix/pom.xml
@@ -46,7 +46,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.0-SNAPSHOT</version>
+                <version>6.1.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.example</basePackage>
@@ -55,7 +55,7 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-jpa</artifactId>
-                        <version>3.1.0-SNAPSHOT</version>
+                        <version>3.1.0</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/test-param-jpa-table-prefix/pom.xml
+++ b/examples/test-param-jpa-table-prefix/pom.xml
@@ -46,7 +46,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.0-SNAPSHOT</version>
+                <version>6.1.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.example</basePackage>
@@ -55,7 +55,7 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-jpa</artifactId>
-                        <version>3.1.0-SNAPSHOT</version>
+                        <version>3.1.0</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/test-param-livingdoc-generate-diagrams/pom.xml
+++ b/examples/test-param-livingdoc-generate-diagrams/pom.xml
@@ -24,7 +24,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.0-SNAPSHOT</version>
+                <version>6.1.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.example</basePackage>
@@ -33,7 +33,7 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-living-doc</artifactId>
-                        <version>3.1.0-SNAPSHOT</version>
+                        <version>3.1.0</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/test-param-livingdoc-include-debug/pom.xml
+++ b/examples/test-param-livingdoc-include-debug/pom.xml
@@ -24,7 +24,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.0-SNAPSHOT</version>
+                <version>6.1.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.example</basePackage>
@@ -33,7 +33,7 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-living-doc</artifactId>
-                        <version>3.1.0-SNAPSHOT</version>
+                        <version>3.1.0</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/test-param-livingdoc-max-properties/pom.xml
+++ b/examples/test-param-livingdoc-max-properties/pom.xml
@@ -24,7 +24,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.0-SNAPSHOT</version>
+                <version>6.1.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.example</basePackage>
@@ -33,7 +33,7 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-living-doc</artifactId>
-                        <version>3.1.0-SNAPSHOT</version>
+                        <version>3.1.0</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/test-param-livingdoc-no-debug/pom.xml
+++ b/examples/test-param-livingdoc-no-debug/pom.xml
@@ -24,7 +24,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.0-SNAPSHOT</version>
+                <version>6.1.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.example</basePackage>
@@ -33,7 +33,7 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-living-doc</artifactId>
-                        <version>3.1.0-SNAPSHOT</version>
+                        <version>3.1.0</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/test-param-livingdoc-no-diagrams/pom.xml
+++ b/examples/test-param-livingdoc-no-diagrams/pom.xml
@@ -24,7 +24,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.0-SNAPSHOT</version>
+                <version>6.1.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.example</basePackage>
@@ -33,7 +33,7 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-living-doc</artifactId>
-                        <version>3.1.0-SNAPSHOT</version>
+                        <version>3.1.0</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/test-param-livingdoc-output-dir/pom.xml
+++ b/examples/test-param-livingdoc-output-dir/pom.xml
@@ -24,7 +24,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.0-SNAPSHOT</version>
+                <version>6.1.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.example</basePackage>
@@ -33,7 +33,7 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-living-doc</artifactId>
-                        <version>3.1.0-SNAPSHOT</version>
+                        <version>3.1.0</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/test-param-output-directory/pom.xml
+++ b/examples/test-param-output-directory/pom.xml
@@ -60,13 +60,13 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.0-SNAPSHOT</version>
+                <version>6.1.0</version>
                 <extensions>true</extensions>
                 <dependencies>
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-jpa</artifactId>
-                        <version>3.1.0-SNAPSHOT</version>
+                        <version>3.1.0</version>
                     </dependency>
                 </dependencies>
                 <configuration>

--- a/examples/test-param-rest-api-package/pom.xml
+++ b/examples/test-param-rest-api-package/pom.xml
@@ -45,7 +45,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.0-SNAPSHOT</version>
+                <version>6.1.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.example</basePackage>
@@ -54,7 +54,7 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-rest</artifactId>
-                        <version>3.1.0-SNAPSHOT</version>
+                        <version>3.1.0</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/test-param-rest-base-path/pom.xml
+++ b/examples/test-param-rest-base-path/pom.xml
@@ -45,7 +45,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.0-SNAPSHOT</version>
+                <version>6.1.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.example</basePackage>
@@ -54,7 +54,7 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-rest</artifactId>
-                        <version>3.1.0-SNAPSHOT</version>
+                        <version>3.1.0</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/test-param-rest-controller-suffix/pom.xml
+++ b/examples/test-param-rest-controller-suffix/pom.xml
@@ -45,7 +45,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.0-SNAPSHOT</version>
+                <version>6.1.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.example</basePackage>
@@ -54,7 +54,7 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-rest</artifactId>
-                        <version>3.1.0-SNAPSHOT</version>
+                        <version>3.1.0</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/test-param-rest-exception-handler-classname/pom.xml
+++ b/examples/test-param-rest-exception-handler-classname/pom.xml
@@ -45,7 +45,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.0-SNAPSHOT</version>
+                <version>6.1.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.example</basePackage>
@@ -54,7 +54,7 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-rest</artifactId>
-                        <version>3.1.0-SNAPSHOT</version>
+                        <version>3.1.0</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/test-param-rest-no-exception-handler/pom.xml
+++ b/examples/test-param-rest-no-exception-handler/pom.xml
@@ -45,7 +45,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.0-SNAPSHOT</version>
+                <version>6.1.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.example</basePackage>
@@ -54,7 +54,7 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-rest</artifactId>
-                        <version>3.1.0-SNAPSHOT</version>
+                        <version>3.1.0</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/test-param-rest-no-openapi/pom.xml
+++ b/examples/test-param-rest-no-openapi/pom.xml
@@ -41,7 +41,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.0-SNAPSHOT</version>
+                <version>6.1.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.example</basePackage>
@@ -50,7 +50,7 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-rest</artifactId>
-                        <version>3.1.0-SNAPSHOT</version>
+                        <version>3.1.0</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/test-param-rest-request-dto-suffix/pom.xml
+++ b/examples/test-param-rest-request-dto-suffix/pom.xml
@@ -45,7 +45,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.0-SNAPSHOT</version>
+                <version>6.1.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.example</basePackage>
@@ -54,7 +54,7 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-rest</artifactId>
-                        <version>3.1.0-SNAPSHOT</version>
+                        <version>3.1.0</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/test-param-skip-validation/pom.xml
+++ b/examples/test-param-skip-validation/pom.xml
@@ -24,13 +24,13 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.0-SNAPSHOT</version>
+                <version>6.1.0</version>
                 <extensions>true</extensions>
                 <dependencies>
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-living-doc</artifactId>
-                        <version>3.1.0-SNAPSHOT</version>
+                        <version>3.1.0</version>
                     </dependency>
                 </dependencies>
                 <configuration>

--- a/examples/test-param-skip/pom.xml
+++ b/examples/test-param-skip/pom.xml
@@ -24,7 +24,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.0-SNAPSHOT</version>
+                <version>6.1.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.example</basePackage>

--- a/examples/test-param-validation-report-path/pom.xml
+++ b/examples/test-param-validation-report-path/pom.xml
@@ -24,7 +24,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.0-SNAPSHOT</version>
+                <version>6.1.0</version>
                 <extensions>true</extensions>
                 <executions>
                     <execution>
@@ -39,7 +39,7 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-living-doc</artifactId>
-                        <version>3.1.0-SNAPSHOT</version>
+                        <version>3.1.0</version>
                     </dependency>
                 </dependencies>
                 <configuration>

--- a/examples/tutorial-audit/pom.xml
+++ b/examples/tutorial-audit/pom.xml
@@ -27,7 +27,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.0-SNAPSHOT</version>
+                <version>6.1.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.example</basePackage>
@@ -36,7 +36,7 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-audit</artifactId>
-                        <version>3.1.0-SNAPSHOT</version>
+                        <version>3.1.0</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/tutorial-living-doc/pom.xml
+++ b/examples/tutorial-living-doc/pom.xml
@@ -27,7 +27,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.0-SNAPSHOT</version>
+                <version>6.1.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.example</basePackage>
@@ -36,7 +36,7 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-living-doc</artifactId>
-                        <version>3.1.0-SNAPSHOT</version>
+                        <version>3.1.0</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/tutorial-validation/pom.xml
+++ b/examples/tutorial-validation/pom.xml
@@ -44,7 +44,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.0-SNAPSHOT</version>
+                <version>6.1.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.example</basePackage>
@@ -56,12 +56,12 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-living-doc</artifactId>
-                        <version>3.1.0-SNAPSHOT</version>
+                        <version>3.1.0</version>
                     </dependency>
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-audit</artifactId>
-                        <version>3.1.0-SNAPSHOT</version>
+                        <version>3.1.0</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/hexaglue-arch/pom.xml
+++ b/hexaglue-arch/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.hexaglue</groupId>
         <artifactId>hexaglue-parent</artifactId>
-        <version>6.1.0-SNAPSHOT</version>
+        <version>6.1.0</version>
     </parent>
 
     <artifactId>hexaglue-arch</artifactId>

--- a/hexaglue-benchmarks/dependency-reduced-pom.xml
+++ b/hexaglue-benchmarks/dependency-reduced-pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>hexaglue-parent</artifactId>
     <groupId>io.hexaglue</groupId>
-    <version>6.1.0-SNAPSHOT</version>
+    <version>6.1.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>hexaglue-benchmarks</artifactId>

--- a/hexaglue-benchmarks/pom.xml
+++ b/hexaglue-benchmarks/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.hexaglue</groupId>
         <artifactId>hexaglue-parent</artifactId>
-        <version>6.1.0-SNAPSHOT</version>
+        <version>6.1.0</version>
     </parent>
 
     <artifactId>hexaglue-benchmarks</artifactId>

--- a/hexaglue-core/pom.xml
+++ b/hexaglue-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.hexaglue</groupId>
         <artifactId>hexaglue-parent</artifactId>
-        <version>6.1.0-SNAPSHOT</version>
+        <version>6.1.0</version>
     </parent>
 
     <artifactId>hexaglue-core</artifactId>

--- a/hexaglue-maven-plugin/pom.xml
+++ b/hexaglue-maven-plugin/pom.xml
@@ -18,6 +18,7 @@
 
     <properties>
         <hexaglue.root>${project.basedir}/..</hexaglue.root>
+        <hexaglue-plugins.version>3.1.0</hexaglue-plugins.version>
     </properties>
 
     <dependencies>
@@ -98,6 +99,9 @@
                         <goal>compile</goal>
                     </goals>
                     <streamLogs>true</streamLogs>
+                    <filterProperties>
+                        <hexaglue-plugins.version>${hexaglue-plugins.version}</hexaglue-plugins.version>
+                    </filterProperties>
                 </configuration>
                 <executions>
                     <execution>

--- a/hexaglue-maven-plugin/pom.xml
+++ b/hexaglue-maven-plugin/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.hexaglue</groupId>
         <artifactId>hexaglue-parent</artifactId>
-        <version>6.1.0-SNAPSHOT</version>
+        <version>6.1.0</version>
     </parent>
 
     <artifactId>hexaglue-maven-plugin</artifactId>

--- a/hexaglue-maven-plugin/src/it/hexagonal-app/pom.xml
+++ b/hexaglue-maven-plugin/src/it/hexagonal-app/pom.xml
@@ -69,7 +69,7 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-jpa</artifactId>
-                        <version>2.0.0-SNAPSHOT</version>
+                        <version>@hexaglue-plugins.version@</version>
                     </dependency>
                     <!-- Required: jakarta.persistence-api is 'provided' in the plugin -->
                     <dependency>

--- a/hexaglue-maven-plugin/src/it/simple-domain/pom.xml
+++ b/hexaglue-maven-plugin/src/it/simple-domain/pom.xml
@@ -69,7 +69,7 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-jpa</artifactId>
-                        <version>2.0.0-SNAPSHOT</version>
+                        <version>@hexaglue-plugins.version@</version>
                     </dependency>
                     <!-- Required: jakarta.persistence-api is 'provided' in the plugin -->
                     <dependency>

--- a/hexaglue-plugins/hexaglue-plugin-audit/README.md
+++ b/hexaglue-plugins/hexaglue-plugin-audit/README.md
@@ -25,7 +25,7 @@ Add the plugin dependency to your `pom.xml`:
 <dependency>
     <groupId>io.hexaglue</groupId>
     <artifactId>hexaglue-plugin-audit</artifactId>
-    <version>2.0.0</version>
+    <version>3.1.0</version>
     <scope>provided</scope>
 </dependency>
 ```
@@ -42,7 +42,7 @@ Add to your HexaGlue Maven plugin configuration:
 <plugin>
     <groupId>io.hexaglue</groupId>
     <artifactId>hexaglue-maven-plugin</artifactId>
-    <version>5.0.0</version>
+    <version>6.1.0</version>
     <extensions>true</extensions>
     <configuration>
         <basePackage>com.example</basePackage>
@@ -51,7 +51,7 @@ Add to your HexaGlue Maven plugin configuration:
         <dependency>
             <groupId>io.hexaglue.plugins</groupId>
             <artifactId>hexaglue-plugin-audit</artifactId>
-            <version>2.0.0</version>
+            <version>3.1.0</version>
         </dependency>
     </dependencies>
 </plugin>
@@ -65,7 +65,7 @@ The audit behavior is controlled via the `<configuration>` parameters of the Hex
 <plugin>
     <groupId>io.hexaglue</groupId>
     <artifactId>hexaglue-maven-plugin</artifactId>
-    <version>5.0.0</version>
+    <version>6.1.0</version>
     <extensions>true</extensions>
     <configuration>
         <basePackage>com.example</basePackage>
@@ -82,7 +82,7 @@ The audit behavior is controlled via the `<configuration>` parameters of the Hex
         <dependency>
             <groupId>io.hexaglue.plugins</groupId>
             <artifactId>hexaglue-plugin-audit</artifactId>
-            <version>2.0.0</version>
+            <version>3.1.0</version>
         </dependency>
     </dependencies>
 </plugin>
@@ -360,7 +360,7 @@ Current test coverage: **176 tests** covering:
 ## Requirements
 
 - Java 17 or higher
-- HexaGlue 5.0.0 or higher
+- HexaGlue 6.1.0 or higher
 - Maven 3.8+ or Gradle 7.0+
 
 ## License

--- a/hexaglue-plugins/hexaglue-plugin-audit/pom.xml
+++ b/hexaglue-plugins/hexaglue-plugin-audit/pom.xml
@@ -7,11 +7,11 @@
     <parent>
         <groupId>io.hexaglue.plugins</groupId>
         <artifactId>hexaglue-plugins</artifactId>
-        <version>6.1.0-SNAPSHOT</version>
+        <version>6.1.0</version>
     </parent>
 
     <artifactId>hexaglue-plugin-audit</artifactId>
-    <version>3.1.0-SNAPSHOT</version>
+    <version>3.1.0</version>
     <packaging>jar</packaging>
 
     <name>HexaGlue DDD Audit Plugin</name>

--- a/hexaglue-plugins/hexaglue-plugin-jpa/pom.xml
+++ b/hexaglue-plugins/hexaglue-plugin-jpa/pom.xml
@@ -7,11 +7,11 @@
     <parent>
         <groupId>io.hexaglue.plugins</groupId>
         <artifactId>hexaglue-plugins</artifactId>
-        <version>6.1.0-SNAPSHOT</version>
+        <version>6.1.0</version>
     </parent>
 
     <artifactId>hexaglue-plugin-jpa</artifactId>
-    <version>3.1.0-SNAPSHOT</version>
+    <version>3.1.0</version>
     <packaging>jar</packaging>
 
     <name>HexaGlue JPA Plugin</name>

--- a/hexaglue-plugins/hexaglue-plugin-living-doc/pom.xml
+++ b/hexaglue-plugins/hexaglue-plugin-living-doc/pom.xml
@@ -7,11 +7,11 @@
     <parent>
         <groupId>io.hexaglue.plugins</groupId>
         <artifactId>hexaglue-plugins</artifactId>
-        <version>6.1.0-SNAPSHOT</version>
+        <version>6.1.0</version>
     </parent>
 
     <artifactId>hexaglue-plugin-living-doc</artifactId>
-    <version>3.1.0-SNAPSHOT</version>
+    <version>3.1.0</version>
     <packaging>jar</packaging>
 
     <name>HexaGlue Living Documentation Plugin</name>

--- a/hexaglue-plugins/hexaglue-plugin-rest/pom.xml
+++ b/hexaglue-plugins/hexaglue-plugin-rest/pom.xml
@@ -7,11 +7,11 @@
     <parent>
         <groupId>io.hexaglue.plugins</groupId>
         <artifactId>hexaglue-plugins</artifactId>
-        <version>6.1.0-SNAPSHOT</version>
+        <version>6.1.0</version>
     </parent>
 
     <artifactId>hexaglue-plugin-rest</artifactId>
-    <version>3.1.0-SNAPSHOT</version>
+    <version>3.1.0</version>
     <packaging>jar</packaging>
 
     <name>HexaGlue REST Plugin</name>

--- a/hexaglue-plugins/hexaglue-plugins-bom/pom.xml
+++ b/hexaglue-plugins/hexaglue-plugins-bom/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.hexaglue.plugins</groupId>
         <artifactId>hexaglue-plugins</artifactId>
-        <version>6.1.0-SNAPSHOT</version>
+        <version>6.1.0</version>
     </parent>
 
     <artifactId>hexaglue-plugins-bom</artifactId>
@@ -18,9 +18,9 @@
 
     <properties>
         <!-- Each plugin has its own version -->
-        <hexaglue-plugin-jpa.version>3.1.0-SNAPSHOT</hexaglue-plugin-jpa.version>
-        <hexaglue-plugin-living-doc.version>3.1.0-SNAPSHOT</hexaglue-plugin-living-doc.version>
-        <hexaglue-plugin-audit.version>3.1.0-SNAPSHOT</hexaglue-plugin-audit.version>
+        <hexaglue-plugin-jpa.version>3.1.0</hexaglue-plugin-jpa.version>
+        <hexaglue-plugin-living-doc.version>3.1.0</hexaglue-plugin-living-doc.version>
+        <hexaglue-plugin-audit.version>3.1.0</hexaglue-plugin-audit.version>
     </properties>
 
     <dependencyManagement>

--- a/hexaglue-plugins/pom.xml
+++ b/hexaglue-plugins/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.hexaglue</groupId>
         <artifactId>hexaglue-parent</artifactId>
-        <version>6.1.0-SNAPSHOT</version>
+        <version>6.1.0</version>
     </parent>
 
     <groupId>io.hexaglue.plugins</groupId>
@@ -28,7 +28,7 @@
     <properties>
         <hexaglue.root>${project.basedir}/..</hexaglue.root>
         <!-- HexaGlue core version (explicit, cannot use ${project.version} because plugins have their own version) -->
-        <hexaglue.version>6.1.0-SNAPSHOT</hexaglue.version>
+        <hexaglue.version>6.1.0</hexaglue.version>
         <!-- jakarta-persistence.version inherited from hexaglue-parent -->
     </properties>
 

--- a/hexaglue-spi/pom.xml
+++ b/hexaglue-spi/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.hexaglue</groupId>
         <artifactId>hexaglue-parent</artifactId>
-        <version>6.1.0-SNAPSHOT</version>
+        <version>6.1.0</version>
     </parent>
 
     <artifactId>hexaglue-spi</artifactId>

--- a/hexaglue-syntax/hexaglue-syntax-api/pom.xml
+++ b/hexaglue-syntax/hexaglue-syntax-api/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.hexaglue</groupId>
         <artifactId>hexaglue-syntax</artifactId>
-        <version>6.1.0-SNAPSHOT</version>
+        <version>6.1.0</version>
     </parent>
 
     <artifactId>hexaglue-syntax-api</artifactId>

--- a/hexaglue-syntax/hexaglue-syntax-spoon/pom.xml
+++ b/hexaglue-syntax/hexaglue-syntax-spoon/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.hexaglue</groupId>
         <artifactId>hexaglue-syntax</artifactId>
-        <version>6.1.0-SNAPSHOT</version>
+        <version>6.1.0</version>
     </parent>
 
     <artifactId>hexaglue-syntax-spoon</artifactId>

--- a/hexaglue-syntax/pom.xml
+++ b/hexaglue-syntax/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.hexaglue</groupId>
         <artifactId>hexaglue-parent</artifactId>
-        <version>6.1.0-SNAPSHOT</version>
+        <version>6.1.0</version>
     </parent>
 
     <artifactId>hexaglue-syntax</artifactId>

--- a/hexaglue-testing/pom.xml
+++ b/hexaglue-testing/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.hexaglue</groupId>
         <artifactId>hexaglue-parent</artifactId>
-        <version>6.1.0-SNAPSHOT</version>
+        <version>6.1.0</version>
     </parent>
 
     <artifactId>hexaglue-testing</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.hexaglue</groupId>
     <artifactId>hexaglue-parent</artifactId>
-    <version>6.1.0-SNAPSHOT</version>
+    <version>6.1.0</version>
     <packaging>pom</packaging>
 
     <name>HexaGlue</name>
@@ -99,7 +99,7 @@
         <pitest-junit5-plugin.version>1.2.3</pitest-junit5-plugin.version>
 
         <!-- Build tools version (fixed, not ${project.version} to work with child modules) -->
-        <hexaglue-build-tools.version>6.1.0-SNAPSHOT</hexaglue-build-tools.version>
+        <hexaglue-build-tools.version>6.1.0</hexaglue-build-tools.version>
 
         <!-- Root directory for license header (overridden in child modules) -->
         <hexaglue.root>${project.basedir}</hexaglue.root>

--- a/scripts/bump-versions.js
+++ b/scripts/bump-versions.js
@@ -232,6 +232,15 @@ function stepManualProperties(coreVersion, pluginsVersion, dryRun) {
     }
   }
 
+  // hexaglue-maven-plugin/pom.xml: <hexaglue-plugins.version> (used by Invoker IT tests)
+  const mavenPluginPomPath = path.join(ROOT, 'hexaglue-maven-plugin', 'pom.xml');
+  let mavenPluginPom = fs.readFileSync(mavenPluginPomPath, 'utf8');
+  const newMavenPluginPom = replaceXmlProperty(mavenPluginPom, 'hexaglue-plugins.version', pluginsVersion);
+  if (newMavenPluginPom !== mavenPluginPom) {
+    changes.push({ file: rel(mavenPluginPomPath), description: `<hexaglue-plugins.version> → ${pluginsVersion}` });
+    if (!dryRun) fs.writeFileSync(mavenPluginPomPath, newMavenPluginPom, 'utf8');
+  }
+
   // hexaglue-plugins-bom/pom.xml: 3 plugin version properties
   const bomPomPath = path.join(PLUGINS_DIR, 'hexaglue-plugins-bom', 'pom.xml');
   let bomPom = fs.readFileSync(bomPomPath, 'utf8');

--- a/scripts/bump-versions.js
+++ b/scripts/bump-versions.js
@@ -152,23 +152,43 @@ function detectCurrentVersions() {
 // ---------------------------------------------------------------------------
 
 /**
- * Step 1: Run mvn versions:set for core and plugins.
+ * Step 1: Run mvn versions:set for core, then update each plugin POM individually.
+ *
+ * The plugins parent POM (hexaglue-plugins) inherits its version from hexaglue-parent,
+ * so mvn versions:set cannot be used on it directly. Instead, we update each child
+ * plugin module's {@code <version>} tag via direct file replacement.
  */
 function stepMvnVersionsSet(coreVersion, pluginsVersion, dryRun) {
   const changes = [];
 
+  // --- Core: use mvn versions:set (works because core parent has its own <version>) ---
   if (dryRun) {
     changes.push({ file: '(mvn versions:set)', description: `Core → ${coreVersion}` });
-    changes.push({ file: '(mvn versions:set)', description: `Plugins → ${pluginsVersion}` });
   } else {
     console.log(`  Running mvn versions:set for core → ${coreVersion} ...`);
     execSync(`mvn versions:set -DnewVersion=${coreVersion} -DgenerateBackupPoms=false -q`, { cwd: ROOT, stdio: 'inherit' });
-
-    console.log(`  Running mvn versions:set for plugins → ${pluginsVersion} ...`);
-    execSync(`mvn versions:set -DnewVersion=${pluginsVersion} -DgenerateBackupPoms=false -q`, { cwd: PLUGINS_DIR, stdio: 'inherit' });
-
     changes.push({ file: '(mvn versions:set)', description: `Core → ${coreVersion}` });
-    changes.push({ file: '(mvn versions:set)', description: `Plugins → ${pluginsVersion}` });
+  }
+
+  // --- Plugins: update <version> in each child plugin POM directly ---
+  const pluginModules = PLUGIN_ARTIFACTS;
+  for (const mod of pluginModules) {
+    const pomPath = path.join(PLUGINS_DIR, mod, 'pom.xml');
+    if (!fs.existsSync(pomPath)) continue;
+    const content = fs.readFileSync(pomPath, 'utf8');
+    // Match the module's own <version> (not parent's): first <version> after </parent> closing tag,
+    // or the <version> right after <artifactId> (line 14 in each plugin POM).
+    // We use a targeted regex: <artifactId>mod</artifactId>\n    <version>...</version>
+    const re = new RegExp(
+      `(<artifactId>${escapeRegex(mod)}</artifactId>\\s*\\n\\s*<version>)[^<]+(<\\/version>)`
+    );
+    if (re.test(content)) {
+      const newContent = content.replace(re, `$1${pluginsVersion}$2`);
+      if (newContent !== content) {
+        changes.push({ file: rel(pomPath), description: `<version> → ${pluginsVersion}` });
+        if (!dryRun) fs.writeFileSync(pomPath, newContent, 'utf8');
+      }
+    }
   }
 
   return changes;
@@ -196,6 +216,20 @@ function stepManualProperties(coreVersion, pluginsVersion, dryRun) {
   if (newRootPom !== rootPom) {
     changes.push({ file: rel(rootPomPath), description: `<hexaglue-build-tools.version> → ${coreVersion}` });
     if (!dryRun) fs.writeFileSync(rootPomPath, newRootPom, 'utf8');
+  }
+
+  // build/tools/pom.xml: standalone <version> (no parent, not handled by versions:set)
+  const buildToolsPomPath = path.join(ROOT, 'build', 'tools', 'pom.xml');
+  if (fs.existsSync(buildToolsPomPath)) {
+    const content = fs.readFileSync(buildToolsPomPath, 'utf8');
+    const re = /(<artifactId>hexaglue-build-tools<\/artifactId>\s*\n\s*<version>)[^<]+(<\/version>)/;
+    if (re.test(content)) {
+      const newContent = content.replace(re, `$1${coreVersion}$2`);
+      if (newContent !== content) {
+        changes.push({ file: rel(buildToolsPomPath), description: `<version> → ${coreVersion}` });
+        if (!dryRun) fs.writeFileSync(buildToolsPomPath, newContent, 'utf8');
+      }
+    }
   }
 
   // hexaglue-plugins-bom/pom.xml: 3 plugin version properties

--- a/scripts/update-case-studies.js
+++ b/scripts/update-case-studies.js
@@ -1,0 +1,400 @@
+#!/usr/bin/env node
+
+/**
+ * update-case-studies.js — Bump versions in case study POMs, build them,
+ * and collect audit-report.json files into the hexaglue-site data directory.
+ *
+ * Usage:
+ *   node scripts/update-case-studies.js --core 6.1.0 --plugins 3.1.0 [--yes] [--dry-run]
+ *
+ * Flags:
+ *   --core <ver>     New core version (io.hexaglue)
+ *   --plugins <ver>  New plugins version (io.hexaglue.plugins)
+ *   --yes            Skip interactive confirmation
+ *   --dry-run        Show planned changes without writing files or building
+ */
+
+import { execSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { createInterface } from 'node:readline';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const ROOT = path.resolve(import.meta.dirname, '..');
+const PROJECTS_ROOT = path.resolve(ROOT, '..');
+const SITE_DIR = path.join(PROJECTS_ROOT, 'hexaglue-site');
+const DEST_DIR = path.join(SITE_DIR, 'src', 'data', 'case-studies');
+
+const CASE_STUDIES = [
+  {
+    key: 'banking-legacy',
+    dir: path.join(PROJECTS_ROOT, 'case-study-banking', 'legacy'),
+    versionStrategy: 'inline', // versions hardcoded near <artifactId>
+  },
+  {
+    key: 'banking-hexagonal',
+    dir: path.join(PROJECTS_ROOT, 'case-study-banking', 'hexagonal'),
+    versionStrategy: 'inline',
+  },
+  {
+    key: 'ecommerce-legacy',
+    dir: path.join(PROJECTS_ROOT, 'case-study-ecommerce', 'legacy'),
+    versionStrategy: 'properties', // uses <hexaglue.version> / <hexaglue-plugins.version>
+  },
+  {
+    key: 'ecommerce-hexagonal',
+    dir: path.join(PROJECTS_ROOT, 'case-study-ecommerce', 'hexagonal'),
+    versionStrategy: 'properties',
+  },
+];
+
+const CORE_ARTIFACTS = ['hexaglue-maven-plugin'];
+const PLUGIN_ARTIFACTS = [
+  'hexaglue-plugin-audit',
+  'hexaglue-plugin-jpa',
+  'hexaglue-plugin-living-doc',
+  'hexaglue-plugin-rest',
+];
+
+// ---------------------------------------------------------------------------
+// CLI parsing
+// ---------------------------------------------------------------------------
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  const opts = { core: null, plugins: null, yes: false, dryRun: false };
+  for (let i = 0; i < args.length; i++) {
+    switch (args[i]) {
+      case '--core':
+        opts.core = args[++i];
+        break;
+      case '--plugins':
+        opts.plugins = args[++i];
+        break;
+      case '--yes':
+        opts.yes = true;
+        break;
+      case '--dry-run':
+        opts.dryRun = true;
+        break;
+      default:
+        console.error(`Unknown flag: ${args[i]}`);
+        process.exit(1);
+    }
+  }
+  if (!opts.core || !opts.plugins) {
+    console.error('Usage: node scripts/update-case-studies.js --core <ver> --plugins <ver> [--yes] [--dry-run]');
+    process.exit(1);
+  }
+  return opts;
+}
+
+// ---------------------------------------------------------------------------
+// Utility functions
+// ---------------------------------------------------------------------------
+
+function escapeRegex(str) {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Replace <version>…</version> closest to a given <artifactId> in XML content.
+ */
+function replaceVersionNearArtifact(content, artifactId, newVersion) {
+  const re = new RegExp(
+    `(<artifactId>${escapeRegex(artifactId)}</artifactId>[\\s\\S]{0,200}?<version>)([^<]+)(</version>)`,
+    'g'
+  );
+  let count = 0;
+  const result = content.replace(re, (_, before, _oldVer, after) => {
+    count++;
+    return `${before}${newVersion}${after}`;
+  });
+  return { content: result, count };
+}
+
+/**
+ * Replace a Maven XML property value: <propName>…</propName>
+ */
+function replaceXmlProperty(content, propertyName, newValue) {
+  const re = new RegExp(
+    `(<${escapeRegex(propertyName)}>)[^<]+(</${escapeRegex(propertyName)}>)`,
+    'g'
+  );
+  return content.replace(re, `$1${newValue}$2`);
+}
+
+async function confirm(message) {
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  return new Promise((resolve) => {
+    rl.question(`${message} [y/N] `, (answer) => {
+      rl.close();
+      resolve(answer.toLowerCase() === 'y');
+    });
+  });
+}
+
+function stripSnapshot(version) {
+  return version.replace(/-SNAPSHOT$/, '');
+}
+
+/**
+ * Detect the Java version required by a Maven project from its POM.
+ * @returns {string|null} e.g. "21", or null if not found
+ */
+function detectJavaVersion(pomPath) {
+  try {
+    const content = fs.readFileSync(pomPath, 'utf8');
+    const match = content.match(/<java\.version>(\d+)<\/java\.version>/);
+    return match ? match[1] : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve JAVA_HOME for a given Java version on macOS.
+ * @returns {string|null} the JAVA_HOME path, or null if unavailable
+ */
+function resolveJavaHome(javaVersion) {
+  if (process.platform !== 'darwin') return null;
+  try {
+    return execSync(`/usr/libexec/java_home -v ${javaVersion}`, { encoding: 'utf8' }).trim();
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Step 1: Bump versions in POMs
+// ---------------------------------------------------------------------------
+
+function bumpVersions(coreVersion, pluginsVersion, dryRun) {
+  const changes = [];
+
+  for (const cs of CASE_STUDIES) {
+    const pomPath = path.join(cs.dir, 'pom.xml');
+    if (!fs.existsSync(pomPath)) {
+      console.warn(`  Warning: ${pomPath} not found, skipping`);
+      continue;
+    }
+
+    let content = fs.readFileSync(pomPath, 'utf8');
+    let modified = false;
+
+    if (cs.versionStrategy === 'properties') {
+      // Replace <hexaglue.version> and <hexaglue-plugins.version>
+      const newContent1 = replaceXmlProperty(content, 'hexaglue.version', coreVersion);
+      if (newContent1 !== content) { content = newContent1; modified = true; }
+
+      const newContent2 = replaceXmlProperty(content, 'hexaglue-plugins.version', pluginsVersion);
+      if (newContent2 !== content) { content = newContent2; modified = true; }
+    } else {
+      // Inline: replace near <artifactId>
+      for (const aid of CORE_ARTIFACTS) {
+        const r = replaceVersionNearArtifact(content, aid, coreVersion);
+        if (r.count > 0) { content = r.content; modified = true; }
+      }
+      for (const aid of PLUGIN_ARTIFACTS) {
+        const r = replaceVersionNearArtifact(content, aid, pluginsVersion);
+        if (r.count > 0) { content = r.content; modified = true; }
+      }
+    }
+
+    if (modified) {
+      changes.push({ key: cs.key, file: pomPath });
+      if (!dryRun) fs.writeFileSync(pomPath, content, 'utf8');
+    }
+  }
+
+  return changes;
+}
+
+// ---------------------------------------------------------------------------
+// Step 2: Build case studies
+// ---------------------------------------------------------------------------
+
+function buildCaseStudies(dryRun) {
+  for (const cs of CASE_STUDIES) {
+    if (!fs.existsSync(cs.dir)) {
+      console.warn(`  Warning: ${cs.dir} not found, skipping`);
+      continue;
+    }
+
+    const pomPath = path.join(cs.dir, 'pom.xml');
+    const javaVersion = detectJavaVersion(pomPath);
+    const javaHome = javaVersion ? resolveJavaHome(javaVersion) : null;
+    const jdkLabel = javaVersion ? ` (JDK ${javaVersion})` : '';
+
+    console.log(`  Building ${cs.key}...${jdkLabel}`);
+    if (!dryRun) {
+      try {
+        const execOpts = { cwd: cs.dir, stdio: 'inherit' };
+        if (javaHome) {
+          execOpts.env = { ...process.env, JAVA_HOME: javaHome };
+        }
+        execSync('mvn clean verify -q', execOpts);
+      } catch (e) {
+        console.error(`  ERROR: Build failed for ${cs.key}`);
+        process.exit(1);
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Step 3: Collect audit-report.json
+// ---------------------------------------------------------------------------
+
+function collectReports(dryRun) {
+  const collected = [];
+
+  if (!dryRun) {
+    fs.mkdirSync(DEST_DIR, { recursive: true });
+  }
+
+  for (const cs of CASE_STUDIES) {
+    const reportPath = path.join(cs.dir, 'target', 'hexaglue', 'reports', 'audit', 'audit-report.json');
+    const destPath = path.join(DEST_DIR, `${cs.key}.json`);
+
+    if (dryRun) {
+      collected.push({ key: cs.key, src: reportPath, dest: destPath });
+      continue;
+    }
+
+    if (!fs.existsSync(reportPath)) {
+      console.warn(`  Warning: ${reportPath} not found, skipping`);
+      continue;
+    }
+
+    fs.copyFileSync(reportPath, destPath);
+
+    // Strip -SNAPSHOT suffixes from version metadata
+    try {
+      const json = JSON.parse(fs.readFileSync(destPath, 'utf8'));
+      let patched = false;
+      if (json.metadata?.hexaglueVersion?.endsWith('-SNAPSHOT')) {
+        json.metadata.hexaglueVersion = stripSnapshot(json.metadata.hexaglueVersion);
+        patched = true;
+      }
+      if (json.metadata?.pluginVersion?.endsWith('-SNAPSHOT')) {
+        json.metadata.pluginVersion = stripSnapshot(json.metadata.pluginVersion);
+        patched = true;
+      }
+      if (patched) {
+        fs.writeFileSync(destPath, JSON.stringify(json, null, 2) + '\n', 'utf8');
+      }
+    } catch {
+      // JSON parse error — leave file as-is
+    }
+
+    collected.push({ key: cs.key, src: reportPath, dest: destPath });
+  }
+
+  return collected;
+}
+
+// ---------------------------------------------------------------------------
+// Step 4: Summary
+// ---------------------------------------------------------------------------
+
+function printSummary(collected) {
+  console.log('');
+  console.log('Summary:');
+  console.log('--------');
+
+  for (const item of collected) {
+    const destPath = item.dest;
+    if (fs.existsSync(destPath)) {
+      try {
+        const data = JSON.parse(fs.readFileSync(destPath, 'utf8'));
+        const score = data.verdict?.score ?? '?';
+        const grade = data.verdict?.grade ?? '?';
+        console.log(`  ${item.key}: score=${score}, grade=${grade}`);
+      } catch {
+        console.log(`  ${item.key}: collected (could not parse)`);
+      }
+    } else {
+      console.log(`  ${item.key}: (dry-run, no file)`);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const opts = parseArgs();
+
+  console.log('');
+  console.log('HexaGlue Case Studies Update');
+  console.log('============================');
+  console.log(`  Core version:    ${opts.core}`);
+  console.log(`  Plugins version: ${opts.plugins}`);
+  console.log(`  Destination:     ${DEST_DIR}`);
+  if (opts.dryRun) console.log('  *** DRY RUN — no files will be modified ***');
+  console.log('');
+
+  // Step 1: Preview version bumps
+  console.log('Step 1: Bump versions in case study POMs');
+  const versionChanges = bumpVersions(opts.core, opts.plugins, true);
+  for (const c of versionChanges) {
+    console.log(`  ${c.key}: pom.xml updated`);
+  }
+  if (versionChanges.length === 0) {
+    console.log('  (no changes needed)');
+  }
+
+  // Preview report collection
+  console.log('');
+  console.log('Step 2: Build 4 case studies (mvn clean verify)');
+  console.log('Step 3: Collect audit-report.json files');
+  for (const cs of CASE_STUDIES) {
+    console.log(`  ${cs.key} → ${cs.key}.json`);
+  }
+
+  console.log('');
+  console.log(`Total: ${versionChanges.length} POM(s) to update, ${CASE_STUDIES.length} builds, ${CASE_STUDIES.length} JSON(s) to collect`);
+
+  if (opts.dryRun) {
+    console.log('');
+    console.log('Dry run complete. No files were modified.');
+    return;
+  }
+
+  // Confirm
+  if (!opts.yes) {
+    const ok = await confirm('Proceed?');
+    if (!ok) {
+      console.log('Aborted.');
+      process.exit(0);
+    }
+  }
+
+  // Execute
+  console.log('');
+  console.log('Applying version bumps...');
+  bumpVersions(opts.core, opts.plugins, false);
+
+  console.log('');
+  console.log('Building case studies...');
+  buildCaseStudies(false);
+
+  console.log('');
+  console.log('Collecting audit reports...');
+  const collected = collectReports(false);
+
+  printSummary(collected);
+
+  console.log('');
+  console.log(`Done. ${collected.length} audit report(s) collected to ${DEST_DIR}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Bump all versions from SNAPSHOT to release (core 6.1.0, plugins 3.1.0) and update documentation to reflect the new versions.

## Motivation

Prepare the 6.1.0 release of HexaGlue core and 3.1.0 release of plugins.

## Changes

- Remove `-SNAPSHOT` suffix from all POMs (core, plugins, examples, test-params, build modules)
- Set CHANGELOG.md release date to 2026-03-09
- Update version references in docs (QUICK_START.md, VALIDATION.md, ARCHITECTURE_AUDIT.md)
- Update hexaglue-plugin-audit README.md with current versions
- Improve `bump-versions.js` to update plugin POMs individually (fixes `mvn versions:set` limitation on inherited parent versions) and handle `build/tools/pom.xml`
- Add `scripts/update-case-studies.js`

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test improvement

## Affected Modules

- [ ] hexaglue-spi
- [ ] hexaglue-core
- [ ] hexaglue-maven-plugin
- [ ] hexaglue-plugin-jpa
- [ ] hexaglue-plugin-living-doc
- [ ] hexaglue-testing
- [x] examples
- [x] docs

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

### Test Plan

- Verify all POM versions are `6.1.0` (core) and `3.1.0` (plugins) with no remaining SNAPSHOT references
- Verify `make compile` succeeds
- Verify `make integration` succeeds on examples

## Breaking Changes

- None

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have run `mvn spotless:apply` to format my code
- [ ] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (`mvn test`)
- [x] I have updated the documentation accordingly
- [ ] I have added Javadoc to public APIs
- [x] My changes don't introduce new compiler warnings

## Additional Notes

Release script improvements: `bump-versions.js` now handles plugin POMs via direct file replacement instead of `mvn versions:set` on the plugins parent (which fails because plugins inherit their parent version from hexaglue-parent).