### PR TITLE
release: bump versions to 6.1.1 / plugins 3.1.1

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -8,8 +8,8 @@ HexaGlue utilise un versioning à deux niveaux :
 
 | Composant | GroupId | Version actuelle | Exemple |
 |-----------|---------|------------------|---------|
-| Core + Maven plugin | `io.hexaglue` | 6.1.1-SNAPSHOT | `hexaglue-parent`, `hexaglue-core`, `hexaglue-maven-plugin` |
-| Plugins | `io.hexaglue.plugins` | 3.1.1-SNAPSHOT | `hexaglue-plugin-jpa`, `hexaglue-plugin-rest`, etc. |
+| Core + Maven plugin | `io.hexaglue` | 6.1.1 | `hexaglue-parent`, `hexaglue-core`, `hexaglue-maven-plugin` |
+| Plugins | `io.hexaglue.plugins` | 3.1.1 | `hexaglue-plugin-jpa`, `hexaglue-plugin-rest`, etc. |
 
 Les plugins ont leur propre cycle de version, indépendant du core.
 

--- a/build/coverage/pom.xml
+++ b/build/coverage/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.hexaglue</groupId>
         <artifactId>hexaglue-build</artifactId>
-        <version>6.1.1-SNAPSHOT</version>
+        <version>6.1.1</version>
     </parent>
 
     <artifactId>hexaglue-build-coverage</artifactId>

--- a/build/distribution/pom.xml
+++ b/build/distribution/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.hexaglue</groupId>
         <artifactId>hexaglue-build</artifactId>
-        <version>6.1.1-SNAPSHOT</version>
+        <version>6.1.1</version>
     </parent>
 
     <artifactId>hexaglue-build-distribution</artifactId>

--- a/build/integration-tests/pom.xml
+++ b/build/integration-tests/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.hexaglue</groupId>
         <artifactId>hexaglue-build</artifactId>
-        <version>6.1.1-SNAPSHOT</version>
+        <version>6.1.1</version>
     </parent>
 
     <artifactId>hexaglue-build-integration-tests</artifactId>

--- a/build/pom.xml
+++ b/build/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.hexaglue</groupId>
         <artifactId>hexaglue-parent</artifactId>
-        <version>6.1.1-SNAPSHOT</version>
+        <version>6.1.1</version>
     </parent>
 
     <artifactId>hexaglue-build</artifactId>

--- a/build/tools/pom.xml
+++ b/build/tools/pom.xml
@@ -7,7 +7,7 @@
     <!-- No parent to avoid circular dependency -->
     <groupId>io.hexaglue</groupId>
     <artifactId>hexaglue-build-tools</artifactId>
-    <version>6.1.1-SNAPSHOT</version>
+    <version>6.1.1</version>
     <packaging>jar</packaging>
 
     <name>HexaGlue Build Tools Configuration</name>

--- a/docs/ARCHITECTURE_AUDIT.md
+++ b/docs/ARCHITECTURE_AUDIT.md
@@ -48,7 +48,7 @@ The audit plugin checks 15 constraints in two categories:
 <plugin>
     <groupId>io.hexaglue</groupId>
     <artifactId>hexaglue-maven-plugin</artifactId>
-    <version>6.1.1-SNAPSHOT</version>
+    <version>6.1.1</version>
     <extensions>true</extensions>
     <configuration>
         <basePackage>com.example</basePackage>
@@ -57,7 +57,7 @@ The audit plugin checks 15 constraints in two categories:
         <dependency>
             <groupId>io.hexaglue.plugins</groupId>
             <artifactId>hexaglue-plugin-audit</artifactId>
-            <version>3.1.1-SNAPSHOT</version>
+            <version>3.1.1</version>
         </dependency>
     </dependencies>
 </plugin>
@@ -367,7 +367,7 @@ Full production configuration:
 <plugin>
     <groupId>io.hexaglue</groupId>
     <artifactId>hexaglue-maven-plugin</artifactId>
-    <version>6.1.1-SNAPSHOT</version>
+    <version>6.1.1</version>
     <extensions>true</extensions>
     <configuration>
         <basePackage>com.example</basePackage>
@@ -377,17 +377,17 @@ Full production configuration:
         <dependency>
             <groupId>io.hexaglue.plugins</groupId>
             <artifactId>hexaglue-plugin-jpa</artifactId>
-            <version>3.1.1-SNAPSHOT</version>
+            <version>3.1.1</version>
         </dependency>
         <dependency>
             <groupId>io.hexaglue.plugins</groupId>
             <artifactId>hexaglue-plugin-living-doc</artifactId>
-            <version>3.1.1-SNAPSHOT</version>
+            <version>3.1.1</version>
         </dependency>
         <dependency>
             <groupId>io.hexaglue.plugins</groupId>
             <artifactId>hexaglue-plugin-audit</artifactId>
-            <version>3.1.1-SNAPSHOT</version>
+            <version>3.1.1</version>
         </dependency>
     </dependencies>
 </plugin>

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -115,7 +115,7 @@ Add this to your `pom.xml`:
 <plugin>
     <groupId>io.hexaglue</groupId>
     <artifactId>hexaglue-maven-plugin</artifactId>
-    <version>6.1.1-SNAPSHOT</version>
+    <version>6.1.1</version>
     <extensions>true</extensions>
     <configuration>
         <basePackage>com.example</basePackage>
@@ -159,7 +159,7 @@ To generate JPA entities and repositories, add the plugin dependency:
 <plugin>
     <groupId>io.hexaglue</groupId>
     <artifactId>hexaglue-maven-plugin</artifactId>
-    <version>6.1.1-SNAPSHOT</version>
+    <version>6.1.1</version>
     <extensions>true</extensions>
     <configuration>
         <basePackage>com.example</basePackage>
@@ -168,7 +168,7 @@ To generate JPA entities and repositories, add the plugin dependency:
         <dependency>
             <groupId>io.hexaglue.plugins</groupId>
             <artifactId>hexaglue-plugin-jpa</artifactId>
-            <version>3.1.1-SNAPSHOT</version>
+            <version>3.1.1</version>
         </dependency>
     </dependencies>
 </plugin>

--- a/examples/sample-audit-violations/pom.xml
+++ b/examples/sample-audit-violations/pom.xml
@@ -64,7 +64,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.1-SNAPSHOT</version>
+                <version>6.1.1</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.example.ecommerce</basePackage>
@@ -76,13 +76,13 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-living-doc</artifactId>
-                        <version>3.1.1-SNAPSHOT</version>
+                        <version>3.1.1</version>
                     </dependency>
                     <!-- DDD Audit Plugin -->
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-audit</artifactId>
-                        <version>3.1.1-SNAPSHOT</version>
+                        <version>3.1.1</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/sample-basic/pom.xml
+++ b/examples/sample-basic/pom.xml
@@ -61,7 +61,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.1-SNAPSHOT</version>
+                <version>6.1.1</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.example</basePackage>
@@ -71,13 +71,13 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-living-doc</artifactId>
-                        <version>3.1.1-SNAPSHOT</version>
+                        <version>3.1.1</version>
                     </dependency>
                     <!-- DDD Audit Plugin -->
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-audit</artifactId>
-                        <version>3.1.1-SNAPSHOT</version>
+                        <version>3.1.1</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/sample-jpa-bugfixes/pom.xml
+++ b/examples/sample-jpa-bugfixes/pom.xml
@@ -66,7 +66,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.1-SNAPSHOT</version>
+                <version>6.1.1</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.university</basePackage>
@@ -76,19 +76,19 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-living-doc</artifactId>
-                        <version>3.1.1-SNAPSHOT</version>
+                        <version>3.1.1</version>
                     </dependency>
                     <!-- JPA Plugin -->
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-jpa</artifactId>
-                        <version>3.1.1-SNAPSHOT</version>
+                        <version>3.1.1</version>
                     </dependency>
                     <!-- DDD Audit Plugin -->
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-audit</artifactId>
-                        <version>3.1.1-SNAPSHOT</version>
+                        <version>3.1.1</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/sample-lombok-multimodule/pom.xml
+++ b/examples/sample-lombok-multimodule/pom.xml
@@ -51,7 +51,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.1-SNAPSHOT</version>
+                <version>6.1.1</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.library</basePackage>
@@ -61,19 +61,19 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-jpa</artifactId>
-                        <version>3.1.1-SNAPSHOT</version>
+                        <version>3.1.1</version>
                     </dependency>
                     <!-- Living Documentation Plugin -->
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-living-doc</artifactId>
-                        <version>3.1.1-SNAPSHOT</version>
+                        <version>3.1.1</version>
                     </dependency>
                     <!-- DDD Audit Plugin -->
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-audit</artifactId>
-                        <version>3.1.1-SNAPSHOT</version>
+                        <version>3.1.1</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/sample-multi-aggregate/pom.xml
+++ b/examples/sample-multi-aggregate/pom.xml
@@ -73,7 +73,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.1-SNAPSHOT</version>
+                <version>6.1.1</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.ecommerce</basePackage>
@@ -83,25 +83,25 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-living-doc</artifactId>
-                        <version>3.1.1-SNAPSHOT</version>
+                        <version>3.1.1</version>
                     </dependency>
                     <!-- JPA Plugin -->
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-jpa</artifactId>
-                        <version>3.1.1-SNAPSHOT</version>
+                        <version>3.1.1</version>
                     </dependency>
                     <!-- DDD Audit Plugin -->
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-audit</artifactId>
-                        <version>3.1.1-SNAPSHOT</version>
+                        <version>3.1.1</version>
                     </dependency>
                     <!-- REST Plugin -->
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-rest</artifactId>
-                        <version>3.1.1-SNAPSHOT</version>
+                        <version>3.1.1</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/sample-multimodule/pom.xml
+++ b/examples/sample-multimodule/pom.xml
@@ -38,7 +38,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.1-SNAPSHOT</version>
+                <version>6.1.1</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.banking</basePackage>
@@ -48,19 +48,19 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-jpa</artifactId>
-                        <version>3.1.1-SNAPSHOT</version>
+                        <version>3.1.1</version>
                     </dependency>
                     <!-- Living Documentation Plugin -->
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-living-doc</artifactId>
-                        <version>3.1.1-SNAPSHOT</version>
+                        <version>3.1.1</version>
                     </dependency>
                     <!-- DDD Audit Plugin -->
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-audit</artifactId>
-                        <version>3.1.1-SNAPSHOT</version>
+                        <version>3.1.1</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/sample-pokedex/pom.xml
+++ b/examples/sample-pokedex/pom.xml
@@ -85,7 +85,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.1-SNAPSHOT</version>
+                <version>6.1.1</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.example</basePackage>
@@ -95,19 +95,19 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-living-doc</artifactId>
-                        <version>3.1.1-SNAPSHOT</version>
+                        <version>3.1.1</version>
                     </dependency>
                     <!-- JPA Plugin -->
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-jpa</artifactId>
-                        <version>3.1.1-SNAPSHOT</version>
+                        <version>3.1.1</version>
                     </dependency>
                     <!-- DDD Audit Plugin -->
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-audit</artifactId>
-                        <version>3.1.1-SNAPSHOT</version>
+                        <version>3.1.1</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/sample-regression-tests/pom.xml
+++ b/examples/sample-regression-tests/pom.xml
@@ -73,7 +73,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.1-SNAPSHOT</version>
+                <version>6.1.1</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.regression</basePackage>
@@ -83,19 +83,19 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-living-doc</artifactId>
-                        <version>3.1.1-SNAPSHOT</version>
+                        <version>3.1.1</version>
                     </dependency>
                     <!-- JPA Plugin -->
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-jpa</artifactId>
-                        <version>3.1.1-SNAPSHOT</version>
+                        <version>3.1.1</version>
                     </dependency>
                     <!-- DDD Audit Plugin -->
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-audit</artifactId>
-                        <version>3.1.1-SNAPSHOT</version>
+                        <version>3.1.1</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/sample-starwars/pom.xml
+++ b/examples/sample-starwars/pom.xml
@@ -61,7 +61,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.1-SNAPSHOT</version>
+                <version>6.1.1</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>rebelsrescue.fleet</basePackage>
@@ -70,17 +70,17 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-living-doc</artifactId>
-                        <version>3.1.1-SNAPSHOT</version>
+                        <version>3.1.1</version>
                     </dependency>
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-jpa</artifactId>
-                        <version>3.1.1-SNAPSHOT</version>
+                        <version>3.1.1</version>
                     </dependency>
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-audit</artifactId>
-                        <version>3.1.1-SNAPSHOT</version>
+                        <version>3.1.1</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/sample-value-objects/pom.xml
+++ b/examples/sample-value-objects/pom.xml
@@ -54,7 +54,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.1-SNAPSHOT</version>
+                <version>6.1.1</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.coffeeshop</basePackage>
@@ -64,19 +64,19 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-living-doc</artifactId>
-                        <version>3.1.1-SNAPSHOT</version>
+                        <version>3.1.1</version>
                     </dependency>
                     <!-- JPA Plugin -->
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-jpa</artifactId>
-                        <version>3.1.1-SNAPSHOT</version>
+                        <version>3.1.1</version>
                     </dependency>
                     <!-- DDD Audit Plugin -->
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-audit</artifactId>
-                        <version>3.1.1-SNAPSHOT</version>
+                        <version>3.1.1</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/test-param-audit-error-on-blocker/pom.xml
+++ b/examples/test-param-audit-error-on-blocker/pom.xml
@@ -24,7 +24,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.1-SNAPSHOT</version>
+                <version>6.1.1</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.example</basePackage>
@@ -35,7 +35,7 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-audit</artifactId>
-                        <version>3.1.1-SNAPSHOT</version>
+                        <version>3.1.1</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/test-param-audit-error-on-critical/pom.xml
+++ b/examples/test-param-audit-error-on-critical/pom.xml
@@ -24,7 +24,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.1-SNAPSHOT</version>
+                <version>6.1.1</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.example</basePackage>
@@ -35,7 +35,7 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-audit</artifactId>
-                        <version>3.1.1-SNAPSHOT</version>
+                        <version>3.1.1</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/test-param-audit-fail-on-error/pom.xml
+++ b/examples/test-param-audit-fail-on-error/pom.xml
@@ -24,7 +24,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.1-SNAPSHOT</version>
+                <version>6.1.1</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.example</basePackage>
@@ -34,7 +34,7 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-audit</artifactId>
-                        <version>3.1.1-SNAPSHOT</version>
+                        <version>3.1.1</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/test-param-audit-generate-docs/pom.xml
+++ b/examples/test-param-audit-generate-docs/pom.xml
@@ -24,7 +24,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.1-SNAPSHOT</version>
+                <version>6.1.1</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.example</basePackage>
@@ -33,7 +33,7 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-audit</artifactId>
-                        <version>3.1.1-SNAPSHOT</version>
+                        <version>3.1.1</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/test-param-audit-no-error-on-blocker/pom.xml
+++ b/examples/test-param-audit-no-error-on-blocker/pom.xml
@@ -24,7 +24,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.1-SNAPSHOT</version>
+                <version>6.1.1</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.example</basePackage>
@@ -35,7 +35,7 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-audit</artifactId>
-                        <version>3.1.1-SNAPSHOT</version>
+                        <version>3.1.1</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/test-param-audit-no-error-on-critical/pom.xml
+++ b/examples/test-param-audit-no-error-on-critical/pom.xml
@@ -24,7 +24,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.1-SNAPSHOT</version>
+                <version>6.1.1</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.example</basePackage>
@@ -35,7 +35,7 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-audit</artifactId>
-                        <version>3.1.1-SNAPSHOT</version>
+                        <version>3.1.1</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/test-param-audit-no-fail-on-error/pom.xml
+++ b/examples/test-param-audit-no-fail-on-error/pom.xml
@@ -24,7 +24,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.1-SNAPSHOT</version>
+                <version>6.1.1</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.example</basePackage>
@@ -34,7 +34,7 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-audit</artifactId>
-                        <version>3.1.1-SNAPSHOT</version>
+                        <version>3.1.1</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/test-param-audit-report-directory/pom.xml
+++ b/examples/test-param-audit-report-directory/pom.xml
@@ -24,7 +24,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.1-SNAPSHOT</version>
+                <version>6.1.1</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.example</basePackage>
@@ -34,7 +34,7 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-audit</artifactId>
-                        <version>3.1.1-SNAPSHOT</version>
+                        <version>3.1.1</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/test-param-classification-exclude/pom.xml
+++ b/examples/test-param-classification-exclude/pom.xml
@@ -24,7 +24,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.1-SNAPSHOT</version>
+                <version>6.1.1</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.example</basePackage>
@@ -33,7 +33,7 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-living-doc</artifactId>
-                        <version>3.1.1-SNAPSHOT</version>
+                        <version>3.1.1</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/test-param-classification-explicit/pom.xml
+++ b/examples/test-param-classification-explicit/pom.xml
@@ -24,7 +24,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.1-SNAPSHOT</version>
+                <version>6.1.1</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.example</basePackage>
@@ -33,7 +33,7 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-living-doc</artifactId>
-                        <version>3.1.1-SNAPSHOT</version>
+                        <version>3.1.1</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/test-param-classification-fail-unclassified-yaml/pom.xml
+++ b/examples/test-param-classification-fail-unclassified-yaml/pom.xml
@@ -24,7 +24,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.1-SNAPSHOT</version>
+                <version>6.1.1</version>
                 <extensions>true</extensions>
                 <executions>
                     <execution>
@@ -42,7 +42,7 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-living-doc</artifactId>
-                        <version>3.1.1-SNAPSHOT</version>
+                        <version>3.1.1</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/test-param-classification-no-inferred/pom.xml
+++ b/examples/test-param-classification-no-inferred/pom.xml
@@ -24,7 +24,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.1-SNAPSHOT</version>
+                <version>6.1.1</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.example</basePackage>
@@ -33,7 +33,7 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-living-doc</artifactId>
-                        <version>3.1.1-SNAPSHOT</version>
+                        <version>3.1.1</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/test-param-fail-on-unclassified/pom.xml
+++ b/examples/test-param-fail-on-unclassified/pom.xml
@@ -24,7 +24,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.1-SNAPSHOT</version>
+                <version>6.1.1</version>
                 <extensions>true</extensions>
                 <executions>
                     <execution>
@@ -39,7 +39,7 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-living-doc</artifactId>
-                        <version>3.1.1-SNAPSHOT</version>
+                        <version>3.1.1</version>
                     </dependency>
                 </dependencies>
                 <configuration>

--- a/examples/test-param-jpa-adapter-suffix/pom.xml
+++ b/examples/test-param-jpa-adapter-suffix/pom.xml
@@ -46,7 +46,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.1-SNAPSHOT</version>
+                <version>6.1.1</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.example</basePackage>
@@ -55,7 +55,7 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-jpa</artifactId>
-                        <version>3.1.1-SNAPSHOT</version>
+                        <version>3.1.1</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/test-param-jpa-embeddable-suffix/pom.xml
+++ b/examples/test-param-jpa-embeddable-suffix/pom.xml
@@ -46,7 +46,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.1-SNAPSHOT</version>
+                <version>6.1.1</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.example</basePackage>
@@ -55,7 +55,7 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-jpa</artifactId>
-                        <version>3.1.1-SNAPSHOT</version>
+                        <version>3.1.1</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/test-param-jpa-enable-auditing/pom.xml
+++ b/examples/test-param-jpa-enable-auditing/pom.xml
@@ -51,7 +51,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.1-SNAPSHOT</version>
+                <version>6.1.1</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.example</basePackage>
@@ -60,7 +60,7 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-jpa</artifactId>
-                        <version>3.1.1-SNAPSHOT</version>
+                        <version>3.1.1</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/test-param-jpa-enable-optimistic-locking/pom.xml
+++ b/examples/test-param-jpa-enable-optimistic-locking/pom.xml
@@ -51,7 +51,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.1-SNAPSHOT</version>
+                <version>6.1.1</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.example</basePackage>
@@ -60,7 +60,7 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-jpa</artifactId>
-                        <version>3.1.1-SNAPSHOT</version>
+                        <version>3.1.1</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/test-param-jpa-entity-suffix/pom.xml
+++ b/examples/test-param-jpa-entity-suffix/pom.xml
@@ -46,7 +46,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.1-SNAPSHOT</version>
+                <version>6.1.1</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.example</basePackage>
@@ -55,7 +55,7 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-jpa</artifactId>
-                        <version>3.1.1-SNAPSHOT</version>
+                        <version>3.1.1</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/test-param-jpa-infra-package/pom.xml
+++ b/examples/test-param-jpa-infra-package/pom.xml
@@ -51,7 +51,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.1-SNAPSHOT</version>
+                <version>6.1.1</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.example</basePackage>
@@ -60,7 +60,7 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-jpa</artifactId>
-                        <version>3.1.1-SNAPSHOT</version>
+                        <version>3.1.1</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/test-param-jpa-mapper-suffix/pom.xml
+++ b/examples/test-param-jpa-mapper-suffix/pom.xml
@@ -46,7 +46,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.1-SNAPSHOT</version>
+                <version>6.1.1</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.example</basePackage>
@@ -55,7 +55,7 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-jpa</artifactId>
-                        <version>3.1.1-SNAPSHOT</version>
+                        <version>3.1.1</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/test-param-jpa-no-adapters/pom.xml
+++ b/examples/test-param-jpa-no-adapters/pom.xml
@@ -51,7 +51,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.1-SNAPSHOT</version>
+                <version>6.1.1</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.example</basePackage>
@@ -60,7 +60,7 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-jpa</artifactId>
-                        <version>3.1.1-SNAPSHOT</version>
+                        <version>3.1.1</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/test-param-jpa-no-embeddables/pom.xml
+++ b/examples/test-param-jpa-no-embeddables/pom.xml
@@ -51,7 +51,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.1-SNAPSHOT</version>
+                <version>6.1.1</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.example</basePackage>
@@ -60,7 +60,7 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-jpa</artifactId>
-                        <version>3.1.1-SNAPSHOT</version>
+                        <version>3.1.1</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/test-param-jpa-no-mappers/pom.xml
+++ b/examples/test-param-jpa-no-mappers/pom.xml
@@ -51,7 +51,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.1-SNAPSHOT</version>
+                <version>6.1.1</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.example</basePackage>
@@ -60,7 +60,7 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-jpa</artifactId>
-                        <version>3.1.1-SNAPSHOT</version>
+                        <version>3.1.1</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/test-param-jpa-no-repositories/pom.xml
+++ b/examples/test-param-jpa-no-repositories/pom.xml
@@ -51,7 +51,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.1-SNAPSHOT</version>
+                <version>6.1.1</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.example</basePackage>
@@ -60,7 +60,7 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-jpa</artifactId>
-                        <version>3.1.1-SNAPSHOT</version>
+                        <version>3.1.1</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/test-param-jpa-repository-suffix/pom.xml
+++ b/examples/test-param-jpa-repository-suffix/pom.xml
@@ -46,7 +46,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.1-SNAPSHOT</version>
+                <version>6.1.1</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.example</basePackage>
@@ -55,7 +55,7 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-jpa</artifactId>
-                        <version>3.1.1-SNAPSHOT</version>
+                        <version>3.1.1</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/test-param-jpa-table-prefix/pom.xml
+++ b/examples/test-param-jpa-table-prefix/pom.xml
@@ -46,7 +46,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.1-SNAPSHOT</version>
+                <version>6.1.1</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.example</basePackage>
@@ -55,7 +55,7 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-jpa</artifactId>
-                        <version>3.1.1-SNAPSHOT</version>
+                        <version>3.1.1</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/test-param-livingdoc-generate-diagrams/pom.xml
+++ b/examples/test-param-livingdoc-generate-diagrams/pom.xml
@@ -24,7 +24,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.1-SNAPSHOT</version>
+                <version>6.1.1</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.example</basePackage>
@@ -33,7 +33,7 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-living-doc</artifactId>
-                        <version>3.1.1-SNAPSHOT</version>
+                        <version>3.1.1</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/test-param-livingdoc-include-debug/pom.xml
+++ b/examples/test-param-livingdoc-include-debug/pom.xml
@@ -24,7 +24,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.1-SNAPSHOT</version>
+                <version>6.1.1</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.example</basePackage>
@@ -33,7 +33,7 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-living-doc</artifactId>
-                        <version>3.1.1-SNAPSHOT</version>
+                        <version>3.1.1</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/test-param-livingdoc-max-properties/pom.xml
+++ b/examples/test-param-livingdoc-max-properties/pom.xml
@@ -24,7 +24,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.1-SNAPSHOT</version>
+                <version>6.1.1</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.example</basePackage>
@@ -33,7 +33,7 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-living-doc</artifactId>
-                        <version>3.1.1-SNAPSHOT</version>
+                        <version>3.1.1</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/test-param-livingdoc-no-debug/pom.xml
+++ b/examples/test-param-livingdoc-no-debug/pom.xml
@@ -24,7 +24,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.1-SNAPSHOT</version>
+                <version>6.1.1</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.example</basePackage>
@@ -33,7 +33,7 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-living-doc</artifactId>
-                        <version>3.1.1-SNAPSHOT</version>
+                        <version>3.1.1</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/test-param-livingdoc-no-diagrams/pom.xml
+++ b/examples/test-param-livingdoc-no-diagrams/pom.xml
@@ -24,7 +24,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.1-SNAPSHOT</version>
+                <version>6.1.1</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.example</basePackage>
@@ -33,7 +33,7 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-living-doc</artifactId>
-                        <version>3.1.1-SNAPSHOT</version>
+                        <version>3.1.1</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/test-param-livingdoc-output-dir/pom.xml
+++ b/examples/test-param-livingdoc-output-dir/pom.xml
@@ -24,7 +24,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.1-SNAPSHOT</version>
+                <version>6.1.1</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.example</basePackage>
@@ -33,7 +33,7 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-living-doc</artifactId>
-                        <version>3.1.1-SNAPSHOT</version>
+                        <version>3.1.1</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/test-param-output-directory/pom.xml
+++ b/examples/test-param-output-directory/pom.xml
@@ -60,13 +60,13 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.1-SNAPSHOT</version>
+                <version>6.1.1</version>
                 <extensions>true</extensions>
                 <dependencies>
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-jpa</artifactId>
-                        <version>3.1.1-SNAPSHOT</version>
+                        <version>3.1.1</version>
                     </dependency>
                 </dependencies>
                 <configuration>

--- a/examples/test-param-rest-api-package/pom.xml
+++ b/examples/test-param-rest-api-package/pom.xml
@@ -45,7 +45,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.1-SNAPSHOT</version>
+                <version>6.1.1</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.example</basePackage>
@@ -54,7 +54,7 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-rest</artifactId>
-                        <version>3.1.1-SNAPSHOT</version>
+                        <version>3.1.1</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/test-param-rest-base-path/pom.xml
+++ b/examples/test-param-rest-base-path/pom.xml
@@ -45,7 +45,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.1-SNAPSHOT</version>
+                <version>6.1.1</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.example</basePackage>
@@ -54,7 +54,7 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-rest</artifactId>
-                        <version>3.1.1-SNAPSHOT</version>
+                        <version>3.1.1</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/test-param-rest-controller-suffix/pom.xml
+++ b/examples/test-param-rest-controller-suffix/pom.xml
@@ -45,7 +45,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.1-SNAPSHOT</version>
+                <version>6.1.1</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.example</basePackage>
@@ -54,7 +54,7 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-rest</artifactId>
-                        <version>3.1.1-SNAPSHOT</version>
+                        <version>3.1.1</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/test-param-rest-exception-handler-classname/pom.xml
+++ b/examples/test-param-rest-exception-handler-classname/pom.xml
@@ -45,7 +45,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.1-SNAPSHOT</version>
+                <version>6.1.1</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.example</basePackage>
@@ -54,7 +54,7 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-rest</artifactId>
-                        <version>3.1.1-SNAPSHOT</version>
+                        <version>3.1.1</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/test-param-rest-no-exception-handler/pom.xml
+++ b/examples/test-param-rest-no-exception-handler/pom.xml
@@ -45,7 +45,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.1-SNAPSHOT</version>
+                <version>6.1.1</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.example</basePackage>
@@ -54,7 +54,7 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-rest</artifactId>
-                        <version>3.1.1-SNAPSHOT</version>
+                        <version>3.1.1</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/test-param-rest-no-openapi/pom.xml
+++ b/examples/test-param-rest-no-openapi/pom.xml
@@ -41,7 +41,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.1-SNAPSHOT</version>
+                <version>6.1.1</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.example</basePackage>
@@ -50,7 +50,7 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-rest</artifactId>
-                        <version>3.1.1-SNAPSHOT</version>
+                        <version>3.1.1</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/test-param-rest-request-dto-suffix/pom.xml
+++ b/examples/test-param-rest-request-dto-suffix/pom.xml
@@ -45,7 +45,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.1-SNAPSHOT</version>
+                <version>6.1.1</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.example</basePackage>
@@ -54,7 +54,7 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-rest</artifactId>
-                        <version>3.1.1-SNAPSHOT</version>
+                        <version>3.1.1</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/test-param-skip-validation/pom.xml
+++ b/examples/test-param-skip-validation/pom.xml
@@ -24,13 +24,13 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.1-SNAPSHOT</version>
+                <version>6.1.1</version>
                 <extensions>true</extensions>
                 <dependencies>
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-living-doc</artifactId>
-                        <version>3.1.1-SNAPSHOT</version>
+                        <version>3.1.1</version>
                     </dependency>
                 </dependencies>
                 <configuration>

--- a/examples/test-param-skip/pom.xml
+++ b/examples/test-param-skip/pom.xml
@@ -24,7 +24,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.1-SNAPSHOT</version>
+                <version>6.1.1</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.example</basePackage>

--- a/examples/test-param-validation-report-path/pom.xml
+++ b/examples/test-param-validation-report-path/pom.xml
@@ -24,7 +24,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.1-SNAPSHOT</version>
+                <version>6.1.1</version>
                 <extensions>true</extensions>
                 <executions>
                     <execution>
@@ -39,7 +39,7 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-living-doc</artifactId>
-                        <version>3.1.1-SNAPSHOT</version>
+                        <version>3.1.1</version>
                     </dependency>
                 </dependencies>
                 <configuration>

--- a/examples/tutorial-audit/pom.xml
+++ b/examples/tutorial-audit/pom.xml
@@ -27,7 +27,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.1-SNAPSHOT</version>
+                <version>6.1.1</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.example</basePackage>
@@ -36,7 +36,7 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-audit</artifactId>
-                        <version>3.1.1-SNAPSHOT</version>
+                        <version>3.1.1</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/tutorial-living-doc/pom.xml
+++ b/examples/tutorial-living-doc/pom.xml
@@ -27,7 +27,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.1-SNAPSHOT</version>
+                <version>6.1.1</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.example</basePackage>
@@ -36,7 +36,7 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-living-doc</artifactId>
-                        <version>3.1.1-SNAPSHOT</version>
+                        <version>3.1.1</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/examples/tutorial-validation/pom.xml
+++ b/examples/tutorial-validation/pom.xml
@@ -44,7 +44,7 @@
             <plugin>
                 <groupId>io.hexaglue</groupId>
                 <artifactId>hexaglue-maven-plugin</artifactId>
-                <version>6.1.1-SNAPSHOT</version>
+                <version>6.1.1</version>
                 <extensions>true</extensions>
                 <configuration>
                     <basePackage>com.example</basePackage>
@@ -56,12 +56,12 @@
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-living-doc</artifactId>
-                        <version>3.1.1-SNAPSHOT</version>
+                        <version>3.1.1</version>
                     </dependency>
                     <dependency>
                         <groupId>io.hexaglue.plugins</groupId>
                         <artifactId>hexaglue-plugin-audit</artifactId>
-                        <version>3.1.1-SNAPSHOT</version>
+                        <version>3.1.1</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/hexaglue-arch/pom.xml
+++ b/hexaglue-arch/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.hexaglue</groupId>
         <artifactId>hexaglue-parent</artifactId>
-        <version>6.1.1-SNAPSHOT</version>
+        <version>6.1.1</version>
     </parent>
 
     <artifactId>hexaglue-arch</artifactId>

--- a/hexaglue-benchmarks/dependency-reduced-pom.xml
+++ b/hexaglue-benchmarks/dependency-reduced-pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>hexaglue-parent</artifactId>
     <groupId>io.hexaglue</groupId>
-    <version>6.1.1-SNAPSHOT</version>
+    <version>6.1.1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>hexaglue-benchmarks</artifactId>

--- a/hexaglue-benchmarks/pom.xml
+++ b/hexaglue-benchmarks/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.hexaglue</groupId>
         <artifactId>hexaglue-parent</artifactId>
-        <version>6.1.1-SNAPSHOT</version>
+        <version>6.1.1</version>
     </parent>
 
     <artifactId>hexaglue-benchmarks</artifactId>

--- a/hexaglue-core/pom.xml
+++ b/hexaglue-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.hexaglue</groupId>
         <artifactId>hexaglue-parent</artifactId>
-        <version>6.1.1-SNAPSHOT</version>
+        <version>6.1.1</version>
     </parent>
 
     <artifactId>hexaglue-core</artifactId>

--- a/hexaglue-maven-plugin/pom.xml
+++ b/hexaglue-maven-plugin/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.hexaglue</groupId>
         <artifactId>hexaglue-parent</artifactId>
-        <version>6.1.1-SNAPSHOT</version>
+        <version>6.1.1</version>
     </parent>
 
     <artifactId>hexaglue-maven-plugin</artifactId>
@@ -18,7 +18,7 @@
 
     <properties>
         <hexaglue.root>${project.basedir}/..</hexaglue.root>
-        <hexaglue-plugins.version>3.1.1-SNAPSHOT</hexaglue-plugins.version>
+        <hexaglue-plugins.version>3.1.1</hexaglue-plugins.version>
     </properties>
 
     <dependencies>
@@ -100,7 +100,7 @@
                     </goals>
                     <streamLogs>true</streamLogs>
                     <filterProperties>
-                        <hexaglue-plugins.version>3.1.1-SNAPSHOT</hexaglue-plugins.version>
+                        <hexaglue-plugins.version>3.1.1</hexaglue-plugins.version>
                     </filterProperties>
                 </configuration>
                 <executions>

--- a/hexaglue-plugins/hexaglue-plugin-audit/README.md
+++ b/hexaglue-plugins/hexaglue-plugin-audit/README.md
@@ -25,7 +25,7 @@ Add the plugin dependency to your `pom.xml`:
 <dependency>
     <groupId>io.hexaglue</groupId>
     <artifactId>hexaglue-plugin-audit</artifactId>
-    <version>3.1.1-SNAPSHOT</version>
+    <version>3.1.1</version>
     <scope>provided</scope>
 </dependency>
 ```
@@ -42,7 +42,7 @@ Add to your HexaGlue Maven plugin configuration:
 <plugin>
     <groupId>io.hexaglue</groupId>
     <artifactId>hexaglue-maven-plugin</artifactId>
-    <version>6.1.1-SNAPSHOT</version>
+    <version>6.1.1</version>
     <extensions>true</extensions>
     <configuration>
         <basePackage>com.example</basePackage>
@@ -51,7 +51,7 @@ Add to your HexaGlue Maven plugin configuration:
         <dependency>
             <groupId>io.hexaglue.plugins</groupId>
             <artifactId>hexaglue-plugin-audit</artifactId>
-            <version>3.1.1-SNAPSHOT</version>
+            <version>3.1.1</version>
         </dependency>
     </dependencies>
 </plugin>
@@ -65,7 +65,7 @@ The audit behavior is controlled via the `<configuration>` parameters of the Hex
 <plugin>
     <groupId>io.hexaglue</groupId>
     <artifactId>hexaglue-maven-plugin</artifactId>
-    <version>6.1.1-SNAPSHOT</version>
+    <version>6.1.1</version>
     <extensions>true</extensions>
     <configuration>
         <basePackage>com.example</basePackage>
@@ -82,7 +82,7 @@ The audit behavior is controlled via the `<configuration>` parameters of the Hex
         <dependency>
             <groupId>io.hexaglue.plugins</groupId>
             <artifactId>hexaglue-plugin-audit</artifactId>
-            <version>3.1.1-SNAPSHOT</version>
+            <version>3.1.1</version>
         </dependency>
     </dependencies>
 </plugin>

--- a/hexaglue-plugins/hexaglue-plugin-audit/pom.xml
+++ b/hexaglue-plugins/hexaglue-plugin-audit/pom.xml
@@ -7,11 +7,11 @@
     <parent>
         <groupId>io.hexaglue.plugins</groupId>
         <artifactId>hexaglue-plugins</artifactId>
-        <version>6.1.1-SNAPSHOT</version>
+        <version>6.1.1</version>
     </parent>
 
     <artifactId>hexaglue-plugin-audit</artifactId>
-    <version>3.1.1-SNAPSHOT</version>
+    <version>3.1.1</version>
     <packaging>jar</packaging>
 
     <name>HexaGlue DDD Audit Plugin</name>

--- a/hexaglue-plugins/hexaglue-plugin-jpa/pom.xml
+++ b/hexaglue-plugins/hexaglue-plugin-jpa/pom.xml
@@ -7,11 +7,11 @@
     <parent>
         <groupId>io.hexaglue.plugins</groupId>
         <artifactId>hexaglue-plugins</artifactId>
-        <version>6.1.1-SNAPSHOT</version>
+        <version>6.1.1</version>
     </parent>
 
     <artifactId>hexaglue-plugin-jpa</artifactId>
-    <version>3.1.1-SNAPSHOT</version>
+    <version>3.1.1</version>
     <packaging>jar</packaging>
 
     <name>HexaGlue JPA Plugin</name>

--- a/hexaglue-plugins/hexaglue-plugin-living-doc/pom.xml
+++ b/hexaglue-plugins/hexaglue-plugin-living-doc/pom.xml
@@ -7,11 +7,11 @@
     <parent>
         <groupId>io.hexaglue.plugins</groupId>
         <artifactId>hexaglue-plugins</artifactId>
-        <version>6.1.1-SNAPSHOT</version>
+        <version>6.1.1</version>
     </parent>
 
     <artifactId>hexaglue-plugin-living-doc</artifactId>
-    <version>3.1.1-SNAPSHOT</version>
+    <version>3.1.1</version>
     <packaging>jar</packaging>
 
     <name>HexaGlue Living Documentation Plugin</name>

--- a/hexaglue-plugins/hexaglue-plugin-rest/pom.xml
+++ b/hexaglue-plugins/hexaglue-plugin-rest/pom.xml
@@ -7,11 +7,11 @@
     <parent>
         <groupId>io.hexaglue.plugins</groupId>
         <artifactId>hexaglue-plugins</artifactId>
-        <version>6.1.1-SNAPSHOT</version>
+        <version>6.1.1</version>
     </parent>
 
     <artifactId>hexaglue-plugin-rest</artifactId>
-    <version>3.1.1-SNAPSHOT</version>
+    <version>3.1.1</version>
     <packaging>jar</packaging>
 
     <name>HexaGlue REST Plugin</name>

--- a/hexaglue-plugins/hexaglue-plugins-bom/pom.xml
+++ b/hexaglue-plugins/hexaglue-plugins-bom/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.hexaglue.plugins</groupId>
         <artifactId>hexaglue-plugins</artifactId>
-        <version>6.1.1-SNAPSHOT</version>
+        <version>6.1.1</version>
     </parent>
 
     <artifactId>hexaglue-plugins-bom</artifactId>
@@ -18,9 +18,9 @@
 
     <properties>
         <!-- Each plugin has its own version -->
-        <hexaglue-plugin-jpa.version>3.1.1-SNAPSHOT</hexaglue-plugin-jpa.version>
-        <hexaglue-plugin-living-doc.version>3.1.1-SNAPSHOT</hexaglue-plugin-living-doc.version>
-        <hexaglue-plugin-audit.version>3.1.1-SNAPSHOT</hexaglue-plugin-audit.version>
+        <hexaglue-plugin-jpa.version>3.1.1</hexaglue-plugin-jpa.version>
+        <hexaglue-plugin-living-doc.version>3.1.1</hexaglue-plugin-living-doc.version>
+        <hexaglue-plugin-audit.version>3.1.1</hexaglue-plugin-audit.version>
     </properties>
 
     <dependencyManagement>

--- a/hexaglue-plugins/pom.xml
+++ b/hexaglue-plugins/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.hexaglue</groupId>
         <artifactId>hexaglue-parent</artifactId>
-        <version>6.1.1-SNAPSHOT</version>
+        <version>6.1.1</version>
     </parent>
 
     <groupId>io.hexaglue.plugins</groupId>
@@ -28,7 +28,7 @@
     <properties>
         <hexaglue.root>${project.basedir}/..</hexaglue.root>
         <!-- HexaGlue core version (explicit, cannot use ${project.version} because plugins have their own version) -->
-        <hexaglue.version>6.1.1-SNAPSHOT</hexaglue.version>
+        <hexaglue.version>6.1.1</hexaglue.version>
         <!-- jakarta-persistence.version inherited from hexaglue-parent -->
     </properties>
 

--- a/hexaglue-spi/pom.xml
+++ b/hexaglue-spi/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.hexaglue</groupId>
         <artifactId>hexaglue-parent</artifactId>
-        <version>6.1.1-SNAPSHOT</version>
+        <version>6.1.1</version>
     </parent>
 
     <artifactId>hexaglue-spi</artifactId>

--- a/hexaglue-syntax/hexaglue-syntax-api/pom.xml
+++ b/hexaglue-syntax/hexaglue-syntax-api/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.hexaglue</groupId>
         <artifactId>hexaglue-syntax</artifactId>
-        <version>6.1.1-SNAPSHOT</version>
+        <version>6.1.1</version>
     </parent>
 
     <artifactId>hexaglue-syntax-api</artifactId>

--- a/hexaglue-syntax/hexaglue-syntax-spoon/pom.xml
+++ b/hexaglue-syntax/hexaglue-syntax-spoon/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.hexaglue</groupId>
         <artifactId>hexaglue-syntax</artifactId>
-        <version>6.1.1-SNAPSHOT</version>
+        <version>6.1.1</version>
     </parent>
 
     <artifactId>hexaglue-syntax-spoon</artifactId>

--- a/hexaglue-syntax/pom.xml
+++ b/hexaglue-syntax/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.hexaglue</groupId>
         <artifactId>hexaglue-parent</artifactId>
-        <version>6.1.1-SNAPSHOT</version>
+        <version>6.1.1</version>
     </parent>
 
     <artifactId>hexaglue-syntax</artifactId>

--- a/hexaglue-testing/pom.xml
+++ b/hexaglue-testing/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.hexaglue</groupId>
         <artifactId>hexaglue-parent</artifactId>
-        <version>6.1.1-SNAPSHOT</version>
+        <version>6.1.1</version>
     </parent>
 
     <artifactId>hexaglue-testing</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.hexaglue</groupId>
     <artifactId>hexaglue-parent</artifactId>
-    <version>6.1.1-SNAPSHOT</version>
+    <version>6.1.1</version>
     <packaging>pom</packaging>
 
     <name>HexaGlue</name>
@@ -99,7 +99,7 @@
         <pitest-junit5-plugin.version>1.2.3</pitest-junit5-plugin.version>
 
         <!-- Build tools version (fixed, not ${project.version} to work with child modules) -->
-        <hexaglue-build-tools.version>6.1.1-SNAPSHOT</hexaglue-build-tools.version>
+        <hexaglue-build-tools.version>6.1.1</hexaglue-build-tools.version>
 
         <!-- Root directory for license header (overridden in child modules) -->
         <hexaglue.root>${project.basedir}</hexaglue.root>


### PR DESCRIPTION
## Summary

Bump all versions to core 6.1.1 / plugins 3.1.1 for release, and update generated documentation.

## Motivation

Release 6.1.1 includes a fix for Lombok delombok in multi-module reactor builds.

## Changes

- Bump core version from 6.1.1-SNAPSHOT to 6.1.1
- Bump plugins version from 3.1.1-SNAPSHOT to 3.1.1
- Update 56 example POMs with new versions
- Update documentation (QUICK_START, ARCHITECTURE_AUDIT, RELEASING, plugin READMEs)
- Regenerate doc metadata JSON

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test improvement

## Affected Modules

- [x] hexaglue-spi
- [x] hexaglue-core
- [x] hexaglue-maven-plugin
- [x] hexaglue-plugin-jpa
- [x] hexaglue-plugin-living-doc
- [x] hexaglue-testing
- [x] examples
- [x] docs

## Testing

- [x] Manual testing performed

### Test Plan

- `make install` passes (BUILD SUCCESS)
- `make doc-check` passes (ALL CHECKS PASSED)

## Breaking Changes

- None

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have run `mvn spotless:apply` to format my code
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (`mvn test`)
- [x] I have updated the documentation accordingly
- [x] I have added Javadoc to public APIs
- [x] My changes don't introduce new compiler warnings